### PR TITLE
Configure uxp when installed as an EKS Addon

### DIFF
--- a/content/uxp/install.md
+++ b/content/uxp/install.md
@@ -20,6 +20,32 @@ up uxp install
 
 Up installs the latest stable [UXP release](https://github.com/upbound/universal-crossplane/releases/) into the `upbound-system` namespace.
 
+### Configure Upbound Universal Crossplane installed as an EKS Addon
+
+If you have installed `uxp` as an EKS Addon, you need to grant `crossplane` and any `provider` additional cluster level roles.
+
+First grant `crossplane` a _cluster-admin_ role.
+
+```bash
+kubectl create clusterrolebinding cluster-crossplane-admin \
+        --clusterrole=cluster-admin \
+        --serviceaccount upbound-system:crossplane
+```
+
+Next, for each installed provider, add _cluster-admin_ role binding. Here is an example for provider `AWS`.
+
+```bash
+# Retrieve provider pod name
+provider_aws=$(kubectl get pods -n upbound-system \
+              | grep aws \
+              | awk '{print $1}')
+
+# Grant cluster-admin role
+kubectl create clusterrolebinding cluster-provider-admin \
+        --clusterrole=cluster-admin \
+        --serviceaccount upbound-system:"$provider_aws"
+```
+
 ### Install a specific Upbound Universal Crossplane version
 Install a specific version of UXP with `up uxp install <version>`. 
 


### PR DESCRIPTION
### Description of your changes

We are working with AWS to provide `uxp` as an EKS Addon. The `uxp` installation has been tailored to fit AWS requirements and the `crossplane-rbac-manager` has been disabled for the installation. 

This means that in order to install and use any provider, customers will need to configure `uxp` by granting additional cluster scope permissions to the `crossplane` pod and `providers` pods.

This PR shows how to perform such configuration using imperative commands.

> This instructions will no longer be needed whenl AWS allows the use of `crossplane-rbac-manager`.

Fixes https://github.com/upbound/platform-core/issues/557

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Locally with `hugo server`