### PR TITLE
docs: removed xgql and fixed bootstrapper references

### DIFF
--- a/content/quickstart/quickstart-common.md
+++ b/content/quickstart/quickstart-common.md
@@ -28,13 +28,7 @@ kubectl get pods -n upbound-system
 NAME                                        READY   STATUS    RESTARTS      AGE
 crossplane-7fdfbd897c-pmrml                 1/1     Running   0             68m
 crossplane-rbac-manager-7d6867bc4d-v7wpb    1/1     Running   0             68m
-upbound-bootstrapper-5f47977d54-t8kvk       1/1     Running   0             68m
-xgql-7c4b74c458-5bf2q                       1/1     Running   3 (67m ago)   68m
 ```
-
-{{< hint type="note" >}}
-`RESTARTS` for the `xgql` pod are normal during initial installation. 
-{{< /hint >}}
 
 For more details about UXP pods, read the [UXP]({{<ref "uxp#universal-crossplane-pods" >}}) section.
 

--- a/content/uxp/_index.md
+++ b/content/uxp/_index.md
@@ -18,14 +18,11 @@ kubectl get pods -n upbound-system
 NAME                                      READY   STATUS    RESTARTS      AGE
 crossplane-58b797d5c-fcsgc                1/1     Running   0             16h
 crossplane-rbac-manager-59f79b9cd-fh4qx   1/1     Running   0             16h
-upbound-bootstrapper-7f4cc75d99-z7znr     1/1     Running   0             16h
-xgql-7c4b74c458-s26tv                     1/1     Running   2 (16h ago)   16h
 ```
 
 * {{< hover label="uxp-pods" line="3" >}}crossplane{{< /hover >}} - The {{< hover label="uxp-pods" line="3" >}}crossplane{{</hover>}} pod is the core controller that extends Kubernetes and installs Crossplane extensions like `Providers`.
 * {{< hover label="uxp-pods" line="4" >}}crossplane-rbac-manager{{< /hover >}} - The {{< hover label="uxp-pods" line="4" >}}crossplane-rbac-manager{{< /hover >}} pod allows Crossplane to create and dynamically adjust [Kubernetes Role-based access control (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) for Crossplane resources in the Kubernetes cluster. 
-* {{< hover label="uxp-pods" line="5" >}}upbound-bootstrapper{{< /hover >}} - Creates and populates TLS certificates for use with the Upbound Cloud Console, `xgql` and kube-apiserver. 
-* {{< hover label="uxp-pods" line="6" >}}xgql{{< /hover >}} - An [open source](https://github.com/upbound/xgql/) GraphQL implementation from Upbound used to improve performance between the Upbound Cloud Console and kube-apiserver.
+* {{< hover label="uxp-pods" line="5" >}}upbound-bootstrapper{{< /hover >}} - Only deployed if explicitly enabled, adds the AWS Marketplace controller that registers this instance with AWS Marketplace.
 
 {{<hint type="info" >}}
 The [Up command-line]({{<ref "cli" >}}) installs Universal Crossplane using a Helm chart. Download the chart from [charts.upbound.io](https://charts.upbound.io/main/) to see the full details of the Universal Crossplane install.

--- a/content/uxp/install.md
+++ b/content/uxp/install.md
@@ -87,8 +87,6 @@ crossplane-75556d97b6-gpzq7                  1/1     Running   0               4
 crossplane-75556d97b6-xm8bj                  1/1     Running   0               4m23s
 crossplane-rbac-manager-8f5c76d46-kvmpm      1/1     Running   0               4m23s
 provider-aws-a1113cd136a1-59b8587f6f-q8bpt   1/1     Running   0               4h55m
-upbound-bootstrapper-5dd76c4fb-g2fv5         1/1     Running   0               4m23s
-xgql-7c4b74c458-rdsfb                        1/1     Running   2 (4m21s ago)   4m23s
 ```
 
 ### Configure Upbound Universal Crossplane installed from the Amazon EKS management console

--- a/content/uxp/upgrade.md
+++ b/content/uxp/upgrade.md
@@ -65,6 +65,4 @@ kubectl get pods -n crossplane-system
 NAME                                       READY   STATUS    RESTARTS     AGE
 crossplane-797c7cd8b6-csp8h                1/1     Running   0            2m7s
 crossplane-rbac-manager-744b86cbcd-c45tk   1/1     Running   0            2m7s
-upbound-bootstrapper-5bbdbf758b-s4zrl      1/1     Running   0            2m7s
-xgql-666f97f4cf-x2lpv                      1/1     Running   1 (2m ago)   2m7s
 ```


### PR DESCRIPTION
### Description of your changes

Updating docs to reflect `xgql` removal from UXP 1.11 as per https://github.com/upbound/universal-crossplane/pull/327.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

N.A.