### PR TITLE
Update footer information as requested in docs-44 #73

### DIFF
--- a/themes/upbound/layouts/partials/footer/content.html
+++ b/themes/upbound/layouts/partials/footer/content.html
@@ -23,7 +23,7 @@
 
     <div class="col footer-links footer-col-1 ms-5">
         <div class="footer-heading">Product</div>
-        <div class="py-2"><a href="https://www.upbound.io/products/universal-cloud-platform">Upbound Cloud</a></div>
+        <div class="py-2"><a href="https://www.upbound.io/product/upbound">Upbound</a></div>
         <div class="py-2"><a href="https://www.upbound.io/products/universal-crossplane">Universal Crossplane</a></div>
         <div class="py-2"><a href="https://marketplace.upbound.io/">Marketplace</a></div>
         <div class="py-2"><a href="https://www.upbound.io/contact">Request Demo</a></div>
@@ -34,7 +34,6 @@
         <div class="footer-heading">Learn</div>
         <div class="py-2"><a href="https://docs.upbound.io">Documentation</a></div>
         <div class="py-2"><a href="https://www.upbound.io/faq">FAQs</a></div>
-        <div class="py-2"><a href="https://status.upbound.io/">System Status</a></div>
     </div>
 
 


### PR DESCRIPTION
@samalipio requested footer changes:

1. Under "Product", Upbound Cloud should be replaced by "Upbound" with a link to [upbound.io/product/upbound](https://www.upbound.io/product/upbound)
2. Under "Learn", the link to "System Status" should be removed until a point in time when [this page ](https://status.upbound.io/)reflects accurate info about the status of the new Upbound product. This page is currently not useful to users and could cause confusion.