### PR TITLE
add GA lifecycle docs

### DIFF
--- a/content/knowledge-base/lifecycle.md
+++ b/content/knowledge-base/lifecycle.md
@@ -4,25 +4,25 @@ title: Product Lifecycle
 
 ## Software List
 
-Upbound provides support and sofwtare maintenance to paid customers. Our supported software products include:
+Upbound provides support and software maintenance to paid customers. Supported software products include:
 
 * [UXP](https://www.upbound.io/product/universal-crossplane)
 * [Official Providers](https://marketplace.upbound.io/providers?tier=official)
 
 ## Maintenance and Updates
 
-Upbound will support Generally Available releases for up to 12 months. Eligible code-fixes will be provided via a new minor release on top of the latest major release branch for up to 3 releases from the most current major release. A major release is identified by a change in the first or second digit in our versioning of X.Y.Z.
+Upbound supports Generally Available releases for up to 12 months. Eligible code-fixes are provided via a new minor release on top of the latest major release branch for up to 3 releases from the most current major release. All software follows semantic versioning of `X.Y.Z`. A major release is a change in the first or second digit. A minor release is a change in the third digit.
 
 ### UXP Schedule
 
-UXP follows the [Crossplane Release Cycle](https://docs.crossplane.io/knowledge-base/guides/release-cycle/). UXP has a major release every 3 months. Minor patch release are made available as needed. Upbound provides support for the current + 3 previous major releases, for a minimum of 12 calendar months of coverage for a given release.
+UXP follows the [Crossplane Release Cycle](https://docs.crossplane.io/knowledge-base/guides/release-cycle/). UXP has a major release every 3 months. Minor patch release are available as needed. Upbound provides support for the current + 3 previous major releases, for a minimum of 12 calendar months of coverage for a given release.
 
 ### Official Provider Schedule
 
-Official providers are updated on an as-needed schedule. Historically this has mapped to major releases twice per month. 
+Official providers are released on an as-needed schedule. Historically this has mapped to major releases twice per month. 
 
-Upbound provides support and patch maintenance for the last 12 months of release on Official Providers. A list of official providers is maintained on the [Upbound Marketplace](https://marketplace.upbound.io/providers?tier=official).
+Upbound provides support and patch maintenance for the last 12 months of release on Official Providers. A list of official providers is here: [Upbound Marketplace](https://marketplace.upbound.io/providers?tier=official).
 
 ## Pre-Releases
 
-Customers with paid support contracts will be eleigible for pre-release cuts on an as-needed basis for all covered software.
+Customers with paid support contracts are eligible for pre-release cuts on an as-needed basis for all covered software.

--- a/content/knowledge-base/lifecycle.md
+++ b/content/knowledge-base/lifecycle.md
@@ -15,7 +15,7 @@ Upbound supports Generally Available releases for up to 12 months.
 All software follows semantic versioning of `X.Y.Z`.
 
 * A major release is a change in the first digit and usually indicates breaking API changes or, in the case of 1.0.0, indicates the first release where the API is considered complete (-enough) and stable.
-* A minor release is a change in the second digit and usually indicates new features added, and usually also includes bug fixes that might not have been released yet in a previous patch release.
+* A minor release is a change in the second digit and indicates new features were added. It could also include new bug fixes that were not included in a previous patch release.
 * A patch release is a change in the third digit and only contains bug fixes, no new features.
 
 ### UXP Schedule

--- a/content/knowledge-base/lifecycle.md
+++ b/content/knowledge-base/lifecycle.md
@@ -1,0 +1,28 @@
+---
+title: Product Lifecycle
+---
+
+## Software List
+
+Upbound provides support and sofwtare maintenance to paid customers. Our supported software products include:
+
+* [UXP](https://www.upbound.io/product/universal-crossplane)
+* [Official Providers](https://marketplace.upbound.io/providers?tier=official)
+
+## Maintenance & Updates
+
+Upbound will support Generally Available releases for up to 12 months. Eligible code-fixes will be provided via a new minor release on top of the latest major release branch for up to 3 releases from the most current major release. A major release is identified by a change in the first or second digit in our versioning of X.Y.Z.
+
+### UXP Schedule
+
+UXP follows the [Crossplane Release Cycle](https://docs.crossplane.io/knowledge-base/guides/release-cycle/). UXP has a major release every 3 months. Minor patch release are made available as needed. Upbound provides support for the current + 3 previous major releases, for a minimum of 12 calendar months of coverage for a given release.
+
+### Official Provider Schedule
+
+Official providers are updated on an as-needed schedule. Historically this has mapped to major releases twice per month. 
+
+Upbound provides support and patch maintenance for the last 12 months of release on Official Providers. A list of official providers is maintained on the [Upbound Marketplace](https://marketplace.upbound.io/providers?tier=official).
+
+## Pre-Releases
+
+Customers with paid support contracts will be eleigible for pre-release cuts on an as-needed basis for all covered software.

--- a/content/knowledge-base/lifecycle.md
+++ b/content/knowledge-base/lifecycle.md
@@ -9,7 +9,7 @@ Upbound provides support and sofwtare maintenance to paid customers. Our support
 * [UXP](https://www.upbound.io/product/universal-crossplane)
 * [Official Providers](https://marketplace.upbound.io/providers?tier=official)
 
-## Maintenance & Updates
+## Maintenance and Updates
 
 Upbound will support Generally Available releases for up to 12 months. Eligible code-fixes will be provided via a new minor release on top of the latest major release branch for up to 3 releases from the most current major release. A major release is identified by a change in the first or second digit in our versioning of X.Y.Z.
 

--- a/content/knowledge-base/lifecycle.md
+++ b/content/knowledge-base/lifecycle.md
@@ -14,7 +14,7 @@ Upbound provides support and software maintenance to paid customers. Supported s
 Upbound supports Generally Available releases for up to 12 months. 
 All software follows semantic versioning of `X.Y.Z`.
 
-* A major release is a change in the first digit and usually indicates breaking API changes or, in the case of 1.0.0, indicates the first release where the API is considered complete (-enough) and stable.
+* A major release is a change in the first digit and usually indicates breaking API changes or, in the case of 1.0.0, indicates the first release where the API is considered complete and stable.
 * A minor release is a change in the second digit and indicates new features were added. It could also include new bug fixes that were not included in a previous patch release.
 * A patch release is a change in the third digit and only contains bug fixes, no new features.
 

--- a/content/knowledge-base/lifecycle.md
+++ b/content/knowledge-base/lifecycle.md
@@ -20,7 +20,7 @@ All software follows semantic versioning of `X.Y.Z`.
 
 ### UXP Schedule
 
-UXP follows the [Crossplane Release Cycle](https://docs.crossplane.io/knowledge-base/guides/release-cycle/). UXP has a major release every 3 months. Minor patch release are available as needed. Upbound provides support for the current + 2 previous major releases.
+UXP follows the [Crossplane Release Cycle](https://docs.crossplane.io/knowledge-base/guides/release-cycle/). UXP has a major release every 3 months. Minor patch releases are available as needed. Upbound provides support for the current + 2 previous minor releases.
 
 ### Official Provider Schedule
 

--- a/content/knowledge-base/lifecycle.md
+++ b/content/knowledge-base/lifecycle.md
@@ -6,20 +6,25 @@ title: Product Lifecycle
 
 Upbound provides support and software maintenance to paid customers. Supported software products include:
 
-* [UXP](https://www.upbound.io/product/universal-crossplane)
-* [Official Providers](https://marketplace.upbound.io/providers?tier=official)
+* [UXP]({{< ref "uxp/_index.md" >}})
+* [Official Providers]({{< ref "upbound-marketplace/providers/_index.md" >}})
 
 ## Maintenance and Updates
 
-Upbound supports Generally Available releases for up to 12 months. Eligible code-fixes are provided via a new minor release on top of the latest major release branch for up to 3 releases from the most current major release. All software follows semantic versioning of `X.Y.Z`. A major release is a change in the first or second digit. A minor release is a change in the third digit.
+Upbound supports Generally Available releases for up to 12 months. 
+All software follows semantic versioning of `X.Y.Z`.
+
+* A major release is a change in the first digit and usually indicates breaking API changes or, in the case of 1.0.0, indicates the first release where the API is considered complete (-enough) and stable.
+* A minor release is a change in the second digit and usually indicates new features added, and usually also includes bug fixes that might not have been released yet in a previous patch release.
+* A patch release is a change in the third digit and only contains bug fixes, no new features.
 
 ### UXP Schedule
 
-UXP follows the [Crossplane Release Cycle](https://docs.crossplane.io/knowledge-base/guides/release-cycle/). UXP has a major release every 3 months. Minor patch release are available as needed. Upbound provides support for the current + 3 previous major releases, for a minimum of 12 calendar months of coverage for a given release.
+UXP follows the [Crossplane Release Cycle](https://docs.crossplane.io/knowledge-base/guides/release-cycle/). UXP has a major release every 3 months. Minor patch release are available as needed. Upbound provides support for the current + 2 previous major releases.
 
 ### Official Provider Schedule
 
-Official providers are released on an as-needed schedule. Historically this has mapped to major releases twice per month. 
+Official providers are released at least monthly. 
 
 Upbound provides support and patch maintenance for the last 12 months of release on Official Providers. A list of official providers is here: [Upbound Marketplace](https://marketplace.upbound.io/providers?tier=official).
 

--- a/content/knowledge-base/lifecycle.md
+++ b/content/knowledge-base/lifecycle.md
@@ -18,6 +18,9 @@ All software follows semantic versioning of `X.Y.Z`.
 * A minor release is a change in the second digit and indicates new features were added. It could also include new bug fixes that were not included in a previous patch release.
 * A patch release is a change in the third digit and only contains bug fixes, no new features.
 
+Upbound fixes bugs in supported major releases and the latest minor release
+Upbound backports only critical bugs (both functional and security) to older minor releases.
+
 ### UXP Schedule
 
 UXP follows the [Crossplane Release Cycle](https://docs.crossplane.io/knowledge-base/guides/release-cycle/). UXP has a major release every 3 months. Minor patch releases are available as needed. Upbound provides support for the current + 2 previous minor releases.


### PR DESCRIPTION
Goal to explain our support lifecycle. Have a few inflight contracts that want express understanding of what we support.