### PR TITLE
More explicit documentation about PAT vs robot tokens

### DIFF
--- a/content/cli/command-reference.md
+++ b/content/cli/command-reference.md
@@ -431,7 +431,12 @@ View secrets created by `up controlplane pull-secret create` with `kubectl get s
 <!-- vale Upbound.Spelling = YES -->
 
 
-Uses an access token to create an entry in the default kubeconfig file for the specified managed control plane. Sets the access token as the current Kubernetes context  
+Uses a personal access token to create an entry in the default kubeconfig file for the specified managed control plane. 
+
+Alternatively, if using the `--file` flag, it will merge and use the supplied configuration.
+
+If successful, the current context will be set to the specified control plane. An invalid token or control plane name will error and not set the current context.
+
 `up controlplane kubeconfig get --token=STRING`
 
 {{< table "table table-sm table-striped cli-ref">}}
@@ -441,12 +446,16 @@ Uses an access token to create an entry in the default kubeconfig file for the s
 |  | `--token=STRING`         | Required token to use in the generated kubeconfig to access the specified managed control plane. Upbound manages this token. |
 {{< /table >}}
 
+{{< hint "warning" >}}
+Upbound does not currently support the use of robot tokens for scoped access to control planes. A [personal access token]({{< relref "concepts/console.md#create-a-personal-access-token" >}}) must be used.
+{{< /hint >}}
+
 **Examples**
 
 * Configure your kubeconfig to connect to `my-control-plane` and grep APIs for Crossplane installed on it
 
 ```shell {copy-lines="1"}
-up ctp kubeconfig get --token <my-token> my-control-plane
+up ctp kubeconfig get --token <my-token> -a my-org my-control-plane
 Current context set to upbound-my-org-my-mcp
 
 kubectl api-resources | grep "crossplane.io"

--- a/content/cli/command-reference.md
+++ b/content/cli/command-reference.md
@@ -435,7 +435,8 @@ Uses a personal access token to create an entry in the default kubeconfig file f
 
 Alternatively, if using the `--file` flag, it will merge and use the supplied configuration.
 
-If successful, the current context will be set to the specified control plane. An invalid token or control plane name will error and not set the current context.
+An incorrect token or control plane name produces an error and doesn't change the
+current context. 
 
 `up controlplane kubeconfig get --token=STRING`
 

--- a/content/cli/command-reference.md
+++ b/content/cli/command-reference.md
@@ -433,7 +433,7 @@ View secrets created by `up controlplane pull-secret create` with `kubectl get s
 
 Uses a personal access token to create an entry in the default kubeconfig file for the specified managed control plane. 
 
-Alternatively, if using the `--file` flag, it will merge and use the supplied configuration.
+The `--file` flag uses the supplied configuration instead.
 
 An incorrect token or control plane name produces an error and doesn't change the
 current context. 


### PR DESCRIPTION
As a result of https://github.com/upbound/squad-upbound-cloud/issues/1265, an immediate action was to be more specific about the current state of token usage in Upbound in our docs.

Long-term, we should design for using service accounts instead of personal credentials.

## How this code was tested
`hugo server` locally to ensure everything renders correctly, including the relref.