### PR TITLE
upbound-marketplace: fix link to xpkg reference

### DIFF
--- a/content/upbound-marketplace/packages.md
+++ b/content/upbound-marketplace/packages.md
@@ -64,7 +64,7 @@ my-repo      configuration   true     23h
 ### Add annotations to your package
 The Upbound Marketplace automatically renders specific metadata annotations into listing pages. Upbound recommends that all package maintainers add these annotations into their `crossplane.yaml`. Adding annotations ensures listing have all the required information like licenses, links to source code, and contact information for maintainers.
 
-Upbound supports all annotations specified in the <a href="https://docs.crossplane.io/latest/reference/xpkg/#object-annotations">xpkg specification</a>.
+Upbound supports all annotations specified in the <a href="https://docs.crossplane.io/v1.10/reference/xpkg/#object-annotations">xpkg specification</a>.
 
 ### Push a package to the repository
 Push a package to the Upbound Marketplace using the `up xpkg push` command.

--- a/content/upbound-marketplace/packages.md
+++ b/content/upbound-marketplace/packages.md
@@ -64,7 +64,7 @@ my-repo      configuration   true     23h
 ### Add annotations to your package
 The Upbound Marketplace automatically renders specific metadata annotations into listing pages. Upbound recommends that all package maintainers add these annotations into their `crossplane.yaml`. Adding annotations ensures listing have all the required information like licenses, links to source code, and contact information for maintainers.
 
-Upbound supports all annotations specified in the <a href="https://docs.crossplane.io/v1.10/reference/xpkg/#object-annotations">xpkg specification</a>.
+Upbound supports all annotations specified in the <a href="https://github.com/crossplane/crossplane/blob/master/contributing/specifications/xpkg.md#object-annotations">xpkg specification</a>.
 
 ### Push a package to the repository
 Push a package to the Upbound Marketplace using the `up xpkg push` command.


### PR DESCRIPTION
This has disappeared in later versions than v0.10, and hence gives a 404.

Alternative: readd the xpkg docs in latest Crossplane docs.