### PR TITLE
adjusted code snippets to work with non-white bgs

### DIFF
--- a/themes/upbound/assets/scss/_color-mode-dark.scss
+++ b/themes/upbound/assets/scss/_color-mode-dark.scss
@@ -8,7 +8,7 @@
     --anchor-link-color: #{darken(#FAFAFA, 25)};
 
     // Single code lines inside text. Code blocks are in _code_theme_dark.scss
-    --code-background: #3D4856;
+    --code-background: #FFFFFF15;
     --code-color: #f8f9fa;
     --code-line-number-color: #8bcbe6;
 

--- a/themes/upbound/assets/scss/_color-mode-light.scss
+++ b/themes/upbound/assets/scss/_color-mode-light.scss
@@ -9,7 +9,7 @@
     --home-resource-bg: #{$up-grey-100};
 
     // Single code lines inside text. Code blocks are in _code_theme_light.scss
-    --code-background: #F2F2F4;
+    --code-background: #03072415;
     --code-color: #686A7C;
     --code-line-number-color: #8bcbe6;
 


### PR DESCRIPTION
previous gray snippet backgrounds would not appear when placed on colored backgrounds, such as hints

this fixes that issue by changing the background to be opacity-based