### PR TITLE
Fix nested header exception

### DIFF
--- a/content/xp-arch-framework/building-apis/building-apis-compositions.md
+++ b/content/xp-arch-framework/building-apis/building-apis-compositions.md
@@ -138,7 +138,7 @@ There's a significant improvement in upstream XP found at [crossplane/crossplane
 
 ### Patching Tips
 
-#### 1. Formatting and alignment
+#### 1. Formatting and alignment {#_1-formatting-and-alignment}
 
 Always ensure that `patches` are aligned with `-base` in your manifests. If you are debugging a composition because its not behaving as expected, just like an "off by one" coding error, forgetting proper indention is a common error--and then your patches aren't even defined and applied correctly.
 
@@ -158,7 +158,7 @@ spec:
         ...
 ```
 
-#### 2. Patch policy
+#### 2. Patch policy {#_2-patch-policy}
 
 Policy can be used to make the patch Required (`fromFieldPath: Required`) and set mergeOptions (`keepMapValues: true`) when patching arrays or maps. In the example below, we're patching an array to a property on a bucket.
 
@@ -183,7 +183,7 @@ spec:
               keepMapValues: true
 ```
 
-#### 3. Propogating data between managed resources
+#### 3. Propogating data between managed resources {#_3-propogating-data-between-managed-resources}
 
 One of the common jobs of composition authors is to exchange data between managed resources in a composition. Whereas the convential use case for patches is to patch from a `spec` supplied by a resource claim to a composed managed resource in a composition, this method of patching is for passing data between two sibling managed resources. To do this, you must publish your desired field from a source managed resource to a custom composite resource `status` field. You can then consume data from this `status` field by a target managed resource.
 
@@ -249,7 +249,7 @@ spec:
           toFieldPath: spec.forProvider.url
 ```
 
-#### 4. Block composition rendering
+#### 4. Block composition rendering {#_4-block-composition-rendering}
 
 A `Required` field will prevent a composition from rendering until it's available. 
 
@@ -273,7 +273,7 @@ In the example above, making this a required patch means the `oidcProvider` reso
 You configure whether a field is required in an XRD, not the composition
 {{< /hint >}}
 
-#### 5. Label Selector matching
+#### 5. Label Selector matching {#_1-label-selector-matching}
 
 Label Selectors will match at the cluster-level on CRDs, so ensure labels on any managed resources are unique.
 
@@ -287,7 +287,7 @@ policyArnSelector:
     role: core-ecr
 ```
 
-#### 6. Use patchsets
+#### 6. Use patchsets {#_6-use-patchsets}
 
 Use patchSets for repetitive patching and keep Compositions from becoming bloated. In the example below, you can see a `patchSet` declaration in the spec of the composition, and then that patch is reused across multiple composed resources.
 
@@ -326,7 +326,7 @@ spec:
 
 ### Other Best Practices
 
-#### 1. Label your compositions
+#### 1. Label your compositions {#_1-label-your-compositions}
 
 Always label the composition in `metadata` for future selection. Composition names must match the DNS spec. Always including the full group name (as below) is a convention, not a requirement. The name has a limit on the length (63-character). The group can be omitted if the name gets too long, but each composition must have a unique name on the cluster.
 
@@ -342,7 +342,7 @@ spec:
   ...
 ```
 
-#### 2. Name composed resources
+#### 2. Name composed resources {#_2-name-composed-resources}
 
 Always name Composed Resources in the resources array of a composition. This makes it easier to debug compositions when they're running because events will print out their name, as oppsoed to an index in an array. In the example below, you can see how we've named three composed resources as part of an XEKS composition.
 
@@ -382,7 +382,7 @@ spec:
 If you use Kuttl to validate composites, managed resources _must_ be named uniquely. It's sometimes helpful to have a nestable composite which sets this unique name.
 {{< /hint >}}
 
-#### 3. Composing resources from multiple Crossplane providers
+#### 3. Composing resources from multiple Crossplane providers {#_3-composing-resources-from-multiple-crossplane-providers}
 
 Be conscious about composing resources from multiple different providers. It's a supported scenario but it brings additional complexity. For example, `Selector` and `References` only work with a single provider today, not with multiple providers.
 

--- a/content/xp-arch-framework/interface-integrations/git-and-gitops.md
+++ b/content/xp-arch-framework/interface-integrations/git-and-gitops.md
@@ -10,7 +10,7 @@ GitOps is an approach for managing a system by declaratively describing desired 
 
 Here are three ways you should plan for integrating git with Crossplane:
 
-### 1. Use git for storing your custom APIs
+### 1. Use git for storing your custom APIs {#_1-use-git-for-storing-your-custom-apis}
 
 Building custom APIs with Crossplane doesn't require users to write code, but you still need to write configurations and definitions as YAML. As with traditional software development, you should store your custom API definitions in a version control system, such as git. You should have an automated build pipeline set up with your git repo to package your APIs in a configuration package, then install the package on your control plane.
 
@@ -18,13 +18,13 @@ Building custom APIs with Crossplane doesn't require users to write code, but yo
 Learn more about how to sturcture your repo and define your APIs in the [Building APIs]({{< ref "xp-arch-framework/building-apis/" >}}) section of this framework.
 {{< /hint >}}
 
-### 2. Use git as an interface to invoking your control plane's APIs 
+### 2. Use git as an interface to invoking your control plane's APIs {#_2-use-git-as-an-interface-to-invoking-your-control-planes-apis}
 
 When users think of `GitOps` with Crossplane, its usually in this regard: whenever a user needs a resource from your control plane, a claim should be created. Whether the claim is created directly by the requesting user or there is a [platform frontend]({{< ref "xp-arch-framework/interface-integrations/platform-frontends.md" >}}) that collects information from a user and creates a claim in the background, claims are the Kubernetes-native way to interact with your API.
 
 Claims themselves are resources with a configuration (a `spec`), and as such can and should be declaratively stored in git. We recommend storing claims in a git repo and then using a GitOps engine such as Argo or Flux--described later on below--to deliver the claims to your control plane.
 
-### 3. Use git to store the infrastructure definition that backs your control plane
+### 3. Use git to store the infrastructure definition that backs your control plane {#_3-use-git-to-store-the-infrastructure-definition-that-backs-your-control-plane}
 
 Your control plane itself is infrastructure, and as such should ideally be defined in git. A [chicken or the egg](https://en.wikipedia.org/wiki/Chicken_or_the_egg) problem is commonly brought up by platform teams who want to use Crossplane to drive their entire platform. We address this in the [single control plane baseline architecture]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md#control-plane-causality-dilemma" >}}) portion of this framework.
 

--- a/content/xp-arch-framework/self-eval.md
+++ b/content/xp-arch-framework/self-eval.md
@@ -8,7 +8,7 @@ This self-evaluation outlines the process for how to go about architecting a cus
 
 ## Architecture Questions
 
-### 1. Who will use your platform?
+### 1. Who will use your platform? {#_1-who-will-use-your-platform}
 
 As an architect of a custom cloud platform, it helps us to remind ourselves that we're building this platform for end users and in most cases multiple personas.
 
@@ -16,7 +16,7 @@ As an architect of a custom cloud platform, it helps us to remind ourselves that
 **Action**: Write down all the teams that you anticipate using your platform.
 {{< /hint >}}
 
-### 2. What causes toil for your users?
+### 2. What causes toil for your users? {#_2-what-causes-toil-for-your-users}
 
 These teams likely have current ways to satisfy their infrastructure resource lifecycle management needs. Which tools do they use? Which things hold them back? How much energy do they spend?
 
@@ -24,7 +24,7 @@ These teams likely have current ways to satisfy their infrastructure resource li
 **Action**: Find out how your users are currently satisfying their needs and which problems they want to solve along with their expected outcomes.
 {{< /hint >}}
 
-### 3. What will your interface look like?
+### 3. What will your interface look like? {#_3-what-will-your-interface-look-like}
 
 Your custom cloud platform has an API. This application programming interface will define how your users are interacting with the platform. It allows you to innovate behind the API. This is a great way for cloud platform teams to provide behind the scenes governance and security. One such security feature can be to always encrypt all data at rest and perhaps in transit without any additional work on behalf of your users. Another example may be to create and persist secrets in a corporate secrets store of choice for your custom platform.
 
@@ -34,7 +34,7 @@ The innovation behind the API approach also allows us to apply corporate standar
 **Action**: Determine what the application programming interface for your platform should look like.
 {{< /hint >}}
 
-### 4. What inputs does your interface need to provide?
+### 4. What inputs does your interface need to provide? {#_4-what-inputs-does-your-interface-need-to-provide}
 
 Think about the simplest API that will provide real benefit to at least one major user of your platform when you start out. Use short feedback loops to find out if you are going down a path of energy well spent for your organization.
 


### PR DESCRIPTION
### The bug:
- When using numbered headers, Hugo auto-generates element IDs with those leading numbers (example: `#1-who-will-use-your-platform`)
- This breaks the ScrollSpy plugin which we use to highlight the current section in the right-hand ToC

![Screenshot 2023-07-25 at 12 34 51 PM](https://github.com/upbound/docs/assets/3732779/8e6b1255-eb76-4bf7-82af-73f77571e422)

### The workaround:
- I couldn't find a long-term solution to dynamically override these auto-gen IDs, so for now I'm adding a custom ID override for each numbered section header.




