### PR TITLE
Fix vale warnings for xp-arch-framework content

### DIFF
--- a/content/xp-arch-framework/_index.md
+++ b/content/xp-arch-framework/_index.md
@@ -5,20 +5,18 @@ icon: "popsicle"
 description: "The Upbound Crossplane Architecture Framework"
 ---
 
-The Upbound Crossplane Architecture Framework provides recommendations and describes best practices to help architects, platform teams, administrators, and other cloud practitioners design API abstractions and operate control planes that are secure, efficient, resilient, and high-performing.
+The Upbound Crossplane Architecture Framework provides recommendations and describes best practices for building on top of Crossplane. It's designed to help architects, platform teams, and cloud practitioners design API abstractions and operate control planes that are secure, resilient, and high-performing.
 
-The Crossplane experts at Upbound have validated the design recommendations and best practices defined in this framework. As Crossplane’s capabilities grow and the industry evolves, this framework will continue to reflect current best practices. 
+The Crossplane experts at Upbound have validated the design recommendations and best practices defined in this framework.
 
-## What's Inside
+## What's inside
 
 This framework organizes content into three sections:
 
 - [Constructing custom APIs]({{< ref "xp-arch-framework/building-apis/" >}}) defines a set of best practices for how organizations should approach building custom APIs using Crossplane compositions and configurations.
-- [Architecting with control planes]({{< ref "xp-arch-framework/architecture/" >}}) defines a set of viable design patterns that can be used when architecting with control planes.
+- [Architect with control planes]({{< ref "xp-arch-framework/architecture/" >}}) defines a set of viable design patterns to incorporate when designing an architecture with control planes.
 - [Interface integrations]({{< ref "xp-arch-framework/interface-integrations/" >}}) provides baseline recommendations for integrating with common control plane interfaces (frontends, monitoring, etc).  
 
-This framework defines a set of viable patterns that can be used when architecting with control planes. 
+## Next steps
 
-## Next Steps
-
-We recommend you start by taking the [self-evaluation]({{< ref "xp-arch-framework/self-eval.md" >}}) exercise defined in this framework. It will put you in the right state of mind to answer questions which will inform how you should build on top of Crossplane.
+Start by taking the [self-evaluation]({{< ref "xp-arch-framework/self-eval.md" >}}) exercise defined in this framework. The self-eval helps think about relevant business requirements which is important to understand before you consider how to build on top of Crossplane.

--- a/content/xp-arch-framework/architecture/_index.md
+++ b/content/xp-arch-framework/architecture/_index.md
@@ -4,32 +4,32 @@ weight: 30
 description: "A guide for how to build with control planes"
 ---
 
-Crossplane is a framework that gives users the ability to create their own Kubernetes-style APIs without needing to write code. When a user creates an instance of Crossplane and installs their custom APIs on it, we call this a `control plane` because the user now has an entity they can use to perform controlling actions--creating, reading, updating, or deleting resources exposed by its APIs.
+Crossplane is a framework that gives users the ability to create their own Kubernetes-style APIs without needing to write code. When a user creates an instance of Crossplane and installs their custom APIs on it, it's called this a `control plane`. The user now has an entity they can use to perform controlling actions--creating, reading, updating, or deleting resources exposed by its APIs.
 
-## Overview
+## Architecture overview
 
-How you choose to architect and implement a solution on Crossplane varies wildly depending on your business goals, platform requirements, where you want to offer services powered by Crossplane, and more. This framework provides two reference architectures:
+How you choose to architect a solution on Crossplane varies depending on multiple things. What are your business goals, platform requirements, or where you want to offer services powered by Crossplane? This framework provides two reference architectures:
 
 1. A baseline architecture for a single control plane
 2. A baseline architecture for running control planes at scale (`N > 1`)
 
-The single control plane baseline architecture provides a minimum recommended baseline for how to build a solution on Crossplane--scoped to a single control plane--and integrate it with a set of common third-party integrations. 
+The single control plane baseline architecture provides a recommended baseline for how to build a solution on Crossplane, scoped to a single control plane. It provides guidance for integrating it with a set of common third-party interfaces. 
 
-Your business requirements may lead you to wanting to deploy multiple control planes for various reasons. We usually see these reasons as needing to "specialize" control planes for certain purposes. If you intend to deploy multiple control planes, we believe the single control plane baseline is still applicable--the difference is you will end up deploying it `N` times and you will also need to consider how to manage your multi-control plane architecture. This framework outlines an architecture that can be applied for control planes at scale and builds on the foundations of the single control plane baseline architecture.
+Your business requirements may lead you to wanting to deploy multiple control planes for various reasons. These reasons are often because you need to "specialize" control planes for certain purposes. Even if you intend to deploy multiple control planes, the single control plane baseline is still applicable. The difference is you end up deploying it `N` times. You must also consider how to manage your multi-control plane architecture. This framework outlines an architecture for control planes at scale and builds on the foundations of the single control plane baseline architecture.
 
-## Specializing Control Planes
+## Specializing control planes
 
-The following are popular reasons we see users pursue a multi-control plane architecture:
+The following are popular reasons to pursue a multi-control plane architecture:
 
 - You may need a control plane per environment
 - You may need a control plane per cloud provider
 - You may need a control plane per organizational unit
 - You may need a control plane to own designated cloud accounts in a provider
-- You may need multiple control planes based on perf and scalability characteristics
+- You may need multiple control planes based on performance and scalability characteristics
 - You may need multiple control planes due to your tenancy and isolation requirements
 
-In any of the above cases, you are "specializing" the responsibilities of a control plane based on a set of business requirements.
+In any of the preceding cases, you are "specializing" the responsibilities of a control plane based on a set of business requirements.
 
-## Next Steps
+## Next steps
 
-Read the [Baseline Control Plane]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md" >}}) architecture for our recommendations for how to set up a single instance of Crossplane.
+Read the [Baseline Control Plane]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md" >}}) architecture for recommendations for how to set up a single instance of Crossplane.

--- a/content/xp-arch-framework/architecture/architecture-baseline-multi.md
+++ b/content/xp-arch-framework/architecture/architecture-baseline-multi.md
@@ -67,7 +67,7 @@ This approach means you create a control plane on a per software environment bas
 
 - Your control plane footprint increases linearly for each environment you want to support.
 
-### Specialize control planes by Cloud
+### Specialize control planes by cloud
 
 This approach means you create control planes on a per hyper scale cloud provider basis. For example, if you needed your platform to operate in both AWS and Azure, you would create at least two control planes:
 

--- a/content/xp-arch-framework/architecture/architecture-baseline-multi.md
+++ b/content/xp-arch-framework/architecture/architecture-baseline-multi.md
@@ -4,14 +4,14 @@ weight: 12
 description: "A guide for how to build with control planes"
 ---
 
-This reference architecture provides a recommended baseline architecture for deploying and operating many Crossplane control planes. When users choose to adopt a control plane architecture that involves multiple control planes, those control planes usually have specialized roles. Two things that need to be considered when running many control planes are:
+This reference architecture provides a recommended baseline architecture for deploying and operating multiple Crossplane control planes. When users choose to adopt a control plane architecture that involves multiple control planes, those control planes often have specialized roles. Two things to consider when running multiple control planes are:
 
 1. What are the boundaries that cause you to specialize a control plane's role?
 2. How do you bootstrap and manage the infrastructure that supports each control plane? 
 
-In a multi-control plane architecture, we recommend a hub-and-spoke model: use a central (hub) control plane whose job is to create specialized control planes (spokes). This pattern is also sometimes called “control plane of control planes”.
+In a multi-control plane architecture, the default recommendation is a hub-and-spoke model. Use a central (hub) control plane whose job is to create specialized control planes (spokes). This pattern is also sometimes called "control plane of control planes."
 
-Just like the baseline single control plane architecture, the solution you ultimately arrive upon will be influenced by your business requirements, and as a result it can vary depending on what you are trying to achieve. The architecture and recommendations in this doc are a starting point for you to branch off of.
+Like the baseline single control plane architecture, the solution you arrive upon depends on your business requirements. As a result, it can vary depending on what you are trying to achieve. The architecture and recommendations in this doc are a starting point for you to branch off of.
 
 {{< hint "note" >}}
 💡 An implementation of this architecture is coming soon! You will be able to use it as a starting point and will be encouraged to tweak it according to your needs.
@@ -23,23 +23,23 @@ Just like the baseline single control plane architecture, the solution you ultim
 
 ## Central (hub) control plane
 
-The multi-control plane architecture involves creating a control plane to serve as a hub whose exclusive job is to manage the specialized control planes (spokes). This architecture is a hub-and-spoke pattern and you will sometimes hear it called “control plane of control planes”. The hub control plane follows the [single control plane]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md" >}}) baseline architecture.
+The multi-control plane architecture involves creating a control plane to serve as a hub. It's exclusive job is to manage the specialized control planes (spokes). This architecture is a hub-and-spoke pattern. You may hear it called "control plane of control planes." The hub control plane follows the [single control plane]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md" >}}) baseline architecture.
 
 ### Configure the hub control plane
 
-The hub control plane should be configured in the following ways:
+Configure the hub control plane in the following ways:
 
-- **APIs:** the only APIs that need to be installed are for creating other control planes (and the infrastructure to back them). To do this, it should be able to create new Kubernetes clusters, install Crossplane into them, and create credentials for each control plane.
-- **cloud account access**: if you plan to deploy control planes into multiple cloud accounts, it needs to be configured accordingly to have access to do this.
+- **APIs:** only install APIs required for creating other control planes (and the infrastructure to back them). To do this, it should be able to create new Kubernetes clusters, install Crossplane into them, and create credentials for each control plane.
+- **cloud account access**: if you plan to deploy control planes into multiple cloud accounts, configure it accordingly to have access to do this.
 
-The hub control plane otherwise follows the standard architecture we encourage for [baseline control planes]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md" >}}):
+The hub control plane otherwise follows the standard architecture encouraged for [baseline control planes]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md" >}}):
 
-- the control plane configuration definition should be stored in git, built as a package and deployed via GitOps engine.
-- claims, which should be created for each specialized (spoke) control plane, should be sourced from git and deployed to the hub control plane via a GitOps engine. 
+- Store the control plane configuration definition in Git, built as a package and deployed via a GitOps engine.
+- Create claims for each specialized (spoke) control plane. Source these claims from Git and deploy them to the hub control plane via a GitOps engine. 
 
 ## Specialized (spoke) control planes
 
-When you create multiple control planes, each control plane's role is usually specialized based on some business requirements. We've documented below the main reasons you may want to consider using multiple control planes and associated tradeoffs:
+When you create multiple control planes, specialize each control plane's role based on your business requirements. The main reasons you may want to consider using multiple control planes and their associated tradeoffs are:
 
 - [Cross-environment requirements]({{< ref "xp-arch-framework/architecture/architecture-baseline-multi.md#specialize-control-planes-by-environment" >}})
 - [Cross-cloud requirements]({{< ref "xp-arch-framework/architecture/architecture-baseline-multi.md#specialize-control-planes-by-cloud" >}})
@@ -51,12 +51,12 @@ When you create multiple control planes, each control plane's role is usually sp
 It's important to note you may combine approaches from this list. For example, you may have cross-environment _and_ tenant isolation requirements. 
 
 {{< hint "tip" >}}
-If after reading this page, you are unsure of whether you need to create multiple control planes, our recommendation is to start simple and try to operate with just a [single control plane]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md#configure-your-control-plane" >}}). You should only begin to look at a multi-control plane architecture when you have strong business requirements to do so or your usage exceeds the capacity of a single control plane.
+If after reading this, you are unsure of whether you need to create multiple control planes, our recommendation is to start simple and try to operate with just a [single control plane]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md#configure-your-control-plane" >}}). You should only begin to look at a multi-control plane architecture when you have strong business requirements to do so or your usage exceeds the capacity of a single control plane.
 {{< /hint >}}
 
 ### Specialize control planes by environment
 
-This approach means you create a control plane on a per software environment basis. This would mean 1 control plane for dev, 1 control plane for staging, 1 control plane for production, etc. Each control plane has a specialized responsibility to only manage resources in its designated environment.
+This approach means you create a control plane on a per software environment basis. This would mean 1 control plane for a development environment, 1 control plane for staging, 1 control plane for production, etc. Each control plane has a specialized responsibility to only manage resources in its designated environment.
 
 **Reasons to apply this approach:**
 
@@ -69,7 +69,7 @@ This approach means you create a control plane on a per software environment bas
 
 ### Specialize control planes by Cloud
 
-This approach means you create control planes on a per hyperscale cloud provider basis. For example, if you needed your platform to operate in both AWS and Azure, you would create at least two control planes:
+This approach means you create control planes on a per hyper scale cloud provider basis. For example, if you needed your platform to operate in both AWS and Azure, you would create at least two control planes:
 
 - a control plane whose responsibility is for handling AWS-related resources
 - a control plane whose responsibility is for handling Azure-related resources
@@ -77,58 +77,58 @@ This approach means you create control planes on a per hyperscale cloud provider
 **Reasons to apply this approach:**
 
 - your organization's cloud consumption spans multiple cloud providers.
-- your disaster recovery plans for your platform require sustained operation if one hyperscale provider suffers from an outage.
+- your disaster recovery plans for your platform require sustained operation if one hyper scale provider suffers from an outage.
 
 **Tradeoffs:**
 
 - Your control plane footprint effectively doubles.
-- By nature of this specialization, you don't treat your control plane as being multi-cloud resource capable (which Crossplane is capable of doing). Depending on the hyperscale provider you want to interact with, you need to change control plane contexts.
+- By nature of this specialization, you don't treat your control plane as being multi-cloud resource capable (which Crossplane is capable of doing). Depending on the hyper scale provider you want to interact with, you need to change control plane contexts.
 
-### Specialize control planes by Organizational Unit
+### Specialize control planes by organizational unit
 
-This approach means you designate a control plane to an organizational unit boundary. Many organizations have their own approach to defining their org structure; when we say "organizational unit," we mean some grouping of individual application teams. For example:
+This approach means you specialize a control plane to an organizational unit boundary. Most organizations have their own approach to defining their org structure. "Organizational unit" in this context means some grouping of individual application teams. For example:
 
 - Teams Alpha, Bravo, Charlie use _control-plane-x_
 - Teams Delta, Echo, Foxtrot use _control-plane-y_
 
 **Reasons to apply this approach:**
 
-- This is usually done for tenancy reasons, which we explain in [tenancy requirements]({{< ref "xp-arch-framework/architecture/architecture-baseline-multi.md#tenancy-requirements" >}}) below.
+- It's done for tenancy reasons. Find the explanation for [tenancy requirements]({{< ref "xp-arch-framework/architecture/architecture-baseline-multi.md#tenancy-requirements" >}}) below.
 
 **Tradeoffs:**
 
 - Your control plane footprint scales with the number of organizational units you onboard. Depending on the size of your org, this could bring considerable operational overhead.
 
-### Specialize control planes by Cloud Account
+### Specialize control planes by cloud account
 
-This approach means you create a control plane on per cloud account basis. By cloud account, we mean a specific billing account (AWS Account, GCP Project, Azure Tenant, etc). Crossplane is able to communicate with external APIs only after a Crossplane provider has been installed in the control plane. 
+This approach means you create a control plane on per cloud account basis. By cloud account, it means a specific billing account (AWS Account, GCP Project, Azure Tenant, etc). Crossplane is able to communicate with external APIs only after you install a Crossplane provider in the control plane. 
 
-Crossplane providers themselves rely on `ProviderConfig` objects to configure and provide authentication details for how to interact with the external service. We explain in [tenancy requirements]({{< ref "xp-arch-framework/architecture/architecture-baseline-multi.md#tenancy-requirements" >}}) below the ways you can set up ProviderConfigs on a control plane to control and give tenants access to provision resources in single or multiple cloud accounts.
+Crossplane providers themselves rely on `ProviderConfig` objects to configure and provide authentication details for how to interact with the external service. It's explained in [tenancy requirements]({{< ref "xp-arch-framework/architecture/architecture-baseline-multi.md#tenancy-requirements" >}}) below the ways you can set up ProviderConfigs on a control plane. You can configure them to control and give tenants access to provision resources in single or multiple cloud accounts.
 
 **Reasons to apply this approach:**
 
-- You have business requirements to demonstrate a tenant is _only_ able to provision or interact with resources from a designated set of cloud accounts.
+- You have business requirements to ensure a tenant is _only_ able to provision or interact with resources from a designated set of cloud accounts.
 - You have security requirements to lock down control planes to designated cloud accounts.
 
 **Tradeoffs:**
 
-- It's hard to estimate how this impacts your control plane footprint, since that's heavily dependent on how strongly your organization has adopted cloud accounts to group/segment your cloud resource usage.
+- It's hard to estimate how this impacts your control plane footprint, since that's dependent on how strongly your organization has adopted cloud accounts to group/segment your cloud resource usage.
 
-### Performance Requirements
+### Performance requirements
 
-This use case is driven by necessity rather than strict business requirements. A single Crossplane control plane has inherent performance characteristics and limitations. If your platform usage will cause you to exceed those performance boundaries, you will have no other choice than to distribute the load across multiple control planes. 
+This use case comes out of a necessity rather than strict business requirements. A single Crossplane control plane has inherent performance characteristics and limitations. If your platform usage causes you to exceed those performance boundaries, you must distribute the load across multiple control planes. 
 
 **Reasons to apply this approach:**
 
-- you anticipate serving more tenants on a control plane than we've measured it can handle.
+- you expect to serve more tenants on a control plane than Upbound has measured it can handle.
 
 **Tradeoffs:**
 
-- You need to create a strategy and method for sharding usage across your control planes.
+- You need to create a strategy and method to shard usage across your control planes.
 
-### Tenancy Requirements
+### Tenancy requirements
 
-Sharing control planes can save cost and simplify administrative overhead. However, much like a shared Kubernetes cluster, shared control planes introduce potential security and performance concerns. In the [single control plane architecture]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md#tenancy-on-your-control-plane" >}}), we explained what tenancy means in Crossplane. If you have security requirements to ensure certain teams are only able to create resources in certain cloud accounts, we strongly recommend adopting a multi-control plane architecture that segments teams to their own control planes.
+Sharing control planes can save cost and simplify administrative overhead. But, much like a shared Kubernetes cluster, shared control planes introduce potential security and performance concerns. The [single control plane architecture]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md#tenancy-on-your-control-plane" >}}) explains what tenancy means in Crossplane. Do you have security requirements to ensure certain teams are only able to create resources in certain cloud accounts? If so, it's recommended you adopt a multi-control plane architecture that segments teams to their own control planes.
 
 ## Configuration
 

--- a/content/xp-arch-framework/building-apis/_index.md
+++ b/content/xp-arch-framework/building-apis/_index.md
@@ -10,29 +10,29 @@ Creating your own, customized API is a core differentiating feature of Crossplan
 If you are not already familiar with core Crossplane concepts, we recommend first reading the upstream [Crossplane concepts](https://docs.crossplane.io/master/concepts/) documentation.
 {{< /hint >}}
 
-## Overview
+## Extend the Kubernetes API
 
-Crossplane gives you the tools to extend the Kubernetes API without needing to write code. According to the [Kubernetes docs](https://kubernetes.io/docs/concepts/overview/kubernetes-api/), "The Kubernetes API lets you query and manipulate the state of API objects in Kubernetes (for example: Pods, Namespaces, ConfigMaps, and Events)." 
+Crossplane gives you the tools to extend the Kubernetes API without needing to write code. According to the [Kubernetes docs](https://kubernetes.io/docs/concepts/overview/kubernetes-api/), "The Kubernetes API lets you query and manipulate the state of API objects in Kubernetes. For example: Pods, Namespaces, ConfigMaps, and Events." 
 
 {{<img src="xp-arch-framework/images/kubernetes-resources.png" alt="Depiction of default Kubernetes resources" size="small" quality="100">}}
 
-Customers use Crossplane because they want to declaratively create and manage resources in an external service. "Resources in an external service" can be many things:
+Customers use Crossplane because they want to declaratively create and manage resources in an external service. "Resources in an external service" can vary:
 
 - a traditional cloud resource like an IAM role or a VM instance
 - a Kafka topic or ACL
 - a database in a SQL server instance
 
-To put this into context, Kubernetes has a component called the `API Server`. This is the front door you must go through to interact with various objects in Kubernetes. The API Server needs to know how to interact with resources which exist outside of a Kubernetes cluster.
+To put this into context, Kubernetes has a component called the `API Server`. It's the front door you must go through to interact with various objects in Kubernetes. The API Server needs to know how to interact with resources which exist outside of a Kubernetes cluster.
 
 {{<img src="xp-arch-framework/images/kubernetes-custom-resources.png" alt="Depiction of how Kubernetes cant talk to custom resources by default" size="small" quality="100">}}
 
 ## How Crossplane enables managing resources in an external service
 
-In the examples above, each resource has an API that can be used to interact with it. You can teach Crossplane how to interact with those APIs. **Crossplane providers** are the building blocks that you can install into Crossplane to teach it how to talk to these resources' APIs. Crossplane providers are packages which bundle and define new Kubernetes custom resources and their associated controllers (that contain the logic for interacting with the external resource's APIs). We call these `managed resources (MRs)` in Crossplane.
+In the preceding example, each resource has an API to interact with it. You can teach Crossplane how to interact with those APIs. **Crossplane providers** are the building blocks that you can install into Crossplane to teach it how to talk to these resources' APIs. Crossplane providers are packages which bundle and define new Kubernetes custom resources and their associated controllers. Controllers contain the logic for interacting with the external resource's APIs. Collectively, Crossplane calls these `managed resources (MRs)`.
 
 {{<img src="xp-arch-framework/images/kubernetes-crossplane-mrs.png" alt="Depiction of how Crossplane facilitates talking to external resources" size="small" quality="100">}}
 
-Managed resources are Kubernetes objects, complete with manifests that are like any other Kubernetes object--They support versions, labels, metadata, etc. Here's an example manifest of the `Server` resource courtesy of the Crossplane provider-azure. 
+Managed resources are Kubernetes objects, complete with manifests that are like any other Kubernetes object--They support versions, labels, metadata, etc. An example manifest of the `Server` resource courtesy of the Crossplane provider-azure. 
 
 ```yaml
 apiVersion: dbforpostgresql.azure.upbound.io/v1beta1
@@ -51,15 +51,15 @@ spec:
     name: azure-postgresql-conn
 ```
 
-Crossplane managed resources attempt to be a 1:1 representation of an external resource in Kubernetes. Installing managed resources into a Crossplane via a Crossplane provider doesn't constitute a custom API; you create a custom API in Crossplane by defining `composite resource (XRs)`, a unique concept to Crossplane.
+Crossplane managed resources attempt to be a 1:1 representation of an external resource in Kubernetes. Installing managed resources into a Crossplane via a Crossplane provider doesn't constitute a custom API. You create a custom API in Crossplane by defining `composite resource (XRs)`, a unique concept to Crossplane.
 
 {{< hint "important" >}}
 📢 Just like any Kubernetes object, you can create new Crossplane managed resources directly. We advise **against** doing this in favor of always using Crossplane composite resources, explained below.
 {{< /hint >}}
 
-## What constitutes a custom API with Crossplane?
+## Custom APIs with Crossplane
 
-As the [upstream Crossplane](https://docs.crossplane.io/master/concepts/) documentation calls out, when it comes to building custom APIs with Crossplane, there are a few components involved:
+As the [upstream Crossplane](https://docs.crossplane.io/master/concepts/) documentation calls out, when it comes to building custom APIs with Crossplane, there are some components involved:
 
 1. A **Composite Resource Definition (XRD)**
 2. A **Composition** or **Compositions**
@@ -69,18 +69,18 @@ As the [upstream Crossplane](https://docs.crossplane.io/master/concepts/) docume
 
 A Composite Resource Definition and composition together give Crossplane enough information to be able to form Composite Resources (XRs).
 
-### What's a composite resource (XR)?
+### Composite resources
 
-Composite resources are Kubernetes objects that you can create without needing to write any code and which define a new API abstraction above Crossplane managed resources. Composite resources are user-defined. While managed resources are powerful, there are some limitations:
+Composite resources are Kubernetes objects that you can create without needing to write any code. They define a new API abstraction that incorporates Crossplane managed resources. Composite resources are user-defined. While managed resources are powerful, there are some limitations:
 
-- High-fidelity APIs mean there are a lot of things to configure in each Managed Resource. Could we pre-configure some of the resources?
-- In many cloud deployments, multiple Managed Resources are required. Can we combine them into a single Resource?
-- In many cases we’d like to abstract the resource. Can users ask for a Database instead of a cloud-provider specific DB?
+- High-fidelity APIs mean there are a lot of things to configure in each Managed Resource. Could you pre-configure some resources?
+- In most cloud deployments, you need to create multiple managed resources. Can you combine them into a single Resource?
+- Oftentimes, you'd like to abstract the resource. Can users ask for a Database instead of a cloud-provider specific DB?
 
 Composite Resources solve these problems. A composite resource requires:
 
-- A **Composite Resource Definition (XRD)** to be authored
-- A **composition** to be authored, which is the implementation component of your composite resource against the XRD (which is the definition). You can have multiple compositions that implement an XRD, but 1 implementation will always be selected when creating a new instance of the composite resource.
+- Someone authors a  **Composite Resource Definition (XRD)**.
+- Someone authors a **composition**, which is the implementation component of your composite resource against the XRD (which is the definition). You can have multiple compositions for an XRD, but 1 implementation is always selected when creating a new instance of the composite resource.
 
 {{<img src="xp-arch-framework/images/xrd.png" alt="Depiction of an XRD" size="small" quality="100">}}
 
@@ -88,14 +88,14 @@ For example, you could define a custom API called `StorageBucket` and you could 
 
 {{<img src="xp-arch-framework/images/xr.png" alt="Depiction of an XR" size="small" quality="100">}}
 
-### What does it mean to compose something?
+### Composing resources
 
-Managed resources should never be created directly. Instead, you create them indirectly as part of composing them with Composite Resources. Not only does this allow you to craft a custom API above the managed resource, it also lets you create a relationship between multiple related managed resources, stitch values between them if needed, adds additional RBAC capabilities and lifecycle management controls.
+You should never create managed resources directly. Instead, create them indirectly as part of composing them with Composite Resources. This allows you to craft a custom API for the managed resource. It also lets you create a relationship between multiple related managed resources, stitch values between them if needed, adds RBAC capabilities and lifecycle management controls.
 
 ## Configure APIs on a control plane
 
-A new instance of Crossplane is like a blank slate: there are no custom APIs installed. You need to install packages that deliver custom APIs which implenent the functionality you desire. This could be a package someone else authored or it could be a package that you have authored yourself. `Control plane configurations` are one of the core building blocks defined by Crossplane and are the recommended package format for distributing APIs onto a control plane. To learn about using configuration packages, read [creating control plane configurations]({{< ref "xp-arch-framework/building-apis/building-apis-configurations.md" >}}).
+A new instance of Crossplane is like a blank slate: there are no custom APIs installed. You need to install packages that deliver custom APIs which have the capabilities you meed. This could be a package someone else authored or it could be a package that you have authored yourself. `Control plane configurations` are one of the core building blocks defined by Crossplane and are the recommended package format for distributing APIs onto a control plane. To learn about using configuration packages, read [creating control plane configurations]({{< ref "xp-arch-framework/building-apis/building-apis-configurations.md" >}}).
 
-## Next Steps
+## Next steps
 
 Read [Authoring XRDs]({{< ref "xp-arch-framework/building-apis/building-apis-xrds.md" >}}) to learn about how to approach defining your own XRDs and incorporate best practices.

--- a/content/xp-arch-framework/building-apis/building-apis-compositions.md
+++ b/content/xp-arch-framework/building-apis/building-apis-compositions.md
@@ -4,33 +4,33 @@ weight: 5
 description: "how to build APIs"
 ---
 
-Compositions are the implementations of the schema you define in your [XRD]({{< ref "xp-arch-framework/building-apis/building-apis-xrds.md" >}}). The composition receives all inputs from the XRD. It's recommended to finalize the API design (composite inputs) before launching into composition authoring. The relationship between XRDs and compositions is one-to-many. You can have multiple compositions that implement the spec of an XRD and you can tell Crossplane which one to select.
+Compositions are the implementations of the schema you define in your [XRD]({{< ref "xp-arch-framework/building-apis/building-apis-xrds.md" >}}). The composition receives all inputs from the XRD. It's recommended to design the API (composite inputs) before launching into composition authoring. The relationship between XRDs and compositions is one-to-N. You can have multiple compositions that define the implementation of the spec of an XRD and you can tell Crossplane which one to select.
 
 {{< hint "important" >}}
 If you are not already familiar with core Crossplane concepts, we recommend first reading the upstream [Crossplane concepts](https://docs.crossplane.io/master/concepts/) documentation.
 {{< /hint >}}
 
-## A Composition's Purpose
+## A composition's purpose
 
 Compositions exist in Crossplane to allow you to create resource abstractions that:
 
 1. Assemble a set of related Crossplane managed resources into a logical grouping, all referenced by a single parent entity.
 2. Using user-defined logic, transform a set of inputs coming from a Crossplane resource claim and apply them to the underlying managed resources.
-3. (Optional) Within the logical grouping, propogate values between managed resources in the composition.
+3. (Optional) Within the logical grouping, propagate values between managed resources in the composition.
 
-## Prototype with Managed Resources First
+## Prototype with managed resources first
 
-Before you begin authoring a composition, we recommend first prototyping the resources you want to compose by creating managed resources directly. The ultimate output of a composite resource is always a set of rendered managed resource manifests. We've found it can be difficult to nail the set of values you need to pass to a managed resource in order for it to create successfully, and starting off by working via your abstraction layer (your composition) can further complicate things. Therefore, we recommend:
+Before you begin authoring a composition, it's recommended you first prototyping the resources you want to compose by creating managed resources directly. The ultimate output of a composite resource is always a set of rendered managed resource manifests. It can be difficult to nail the values you need to pass to a managed resource in order for it to create. Starting off by working via your abstraction layer (your composition) can further complicate things. It's recommended you follow this flow:
 
 1. Prototype and directly create the set of managed resources you intend to compose _first_.
-2. Once you've proven to yourself that you can create this set of resources, identify the fields which should be controlled by the consumer of the API.
+2. Once you've proven to yourself that you can create this set of resources, identify the fields the consumer of your API should control.
 3. _Then_ author your composition to map those inputs in their proper format (patching and transforming values, etc).
 
-If you author your composition correctly, the rendered managed resources manifests will be nearly identical to the set of manifests you manually put together during your prototyping phase.
+A composition that's authored right should result in rendered managed resources manifests. These manifests should be identical to what you manually put together during your prototyping phase.
 
 ## Scaffolding a composition
 
-Compositions follow the [OpenAPI](https://swagger.io/specification/) “structural schema”. Below is boilerplate .YAML that you can use to scaffold the beginning of a composition.
+Compositions follow the [OpenAPI](https://swagger.io/specification/) "structural schema." Below is boilerplate .YAML that you can use to scaffold the beginning of a composition.
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -56,7 +56,7 @@ spec:
 
 ## Composition versioning
 
-As described in [versioning an XRD]({{< ref "xp-arch-framework/building-apis/building-apis-xrds.md#versioning" >}}), when you change the shape of an API and define a new version (such as going from v1alpha1 -> v1alpha2) in your XRD, you must create a new composition that implements the new version. To do this, define a new composition object, and point the `compositionTypeRef` to the new API version.
+As described in [versioning an XRD]({{< ref "xp-arch-framework/building-apis/building-apis-xrds.md#versioning" >}}), a version change in the XRD (such as going from v1alpha1 -> v1alpha2) requires a new composition that implements the new version. To do this, define a new composition object, and point the `compositionTypeRef` to the new API version.
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -73,7 +73,7 @@ spec:
 Deploying a new version will automatically upgrade the existing version on all clusters. Only one version can be "live" at a time, which is dictated by the `served` field in the XRD.
 {{< /hint >}}
 
-## Layering Composite Resources
+## Layering composite resources
 
 Composite resources are user-defined. You can layer composite resources on one another by crafting your composition implementations to compose both managed resources _and_ composite resources. Notice in the example below, it defines a composition that composes four _other_ composite resources (_XCompositeAmplify_, _XCompositeCognito_, _XCompositeGateway_, and _XCompositeFunction_)
 
@@ -115,32 +115,32 @@ spec:
           ...
 ```
 
-### When should I layer compositions?
+### When to layer compositions
 
 As a best practice, always start by defining your compositions as a flat list of composed managed resources. The complexity involved with debugging a nested composition increases because:
 
 - there are more layers of objects (and associated events) that you must parse through.
 - more layers of patching to keep track of.
 
-Therefore, start out by composing resources in a flat list. Below are some scenarios where you may want to consider using nested composites:
+Start out by composing resources in a flat list. Below are some scenarios where you may want to consider using nested composites:
 
 1. If you find yourself repetitively copying around definitions of managed resources in your compositions, that would be an appropriate time to consider refactoring those resources into their own compositions and nest them. 
-2. If you have a set of common resource abstractions (such as a standard VPC or bucket) that you tend to use in tandem with other resources, because you'll be reusing these resource abstractions many times, you can compose them once and then nest then in other compositions as needed.
-3. In cases where when another team is the owner of a particular managed resource. For example, suppose one team owns "infra," but wishes to use IAM Policies established by a "security" team. The security team can author "IAMPolicy" composites and the "infra" team can consume those.
+2. If you have a set of common resource abstractions (such as a standard VPC or bucket) that you tend to use in tandem with other resources, you can compose them once and then nest then in other compositions as needed. 
+3. In cases where when another team is the owner of a particular managed resource. For example, suppose one team owns "infra," but wishes to use IAM Policies established by a "security" team. The security team can author `IAMPolicy` composites and the "infra" team can consume those.
 
 {{< hint "important" >}}
 Be careful not to misinterpret nesting composite resources as nesting **claims** inside compositions. You cannot nest Crossplane claim objects in compositions--only other composite resources.
 {{< /hint >}}
 
-## Composition Best Practices
+## Composition best practices
 
-There's a significant improvement in upstream XP found at [crossplane/crossplane#3756](https://github.com/crossplane/crossplane/pull/3756). This enhancement introduces the `--enable-composition-webhook-schema-validation` flag, which can be enabled to greatly enhance developer experience. By enabling this flag, you gain a fast feedback loop during the composition crafting process, leading to more efficient and productive development.
+There's a significant improvement in upstream XP found at [crossplane/crossplane#3756](https://github.com/crossplane/crossplane/pull/3756). This enhancement introduces the `--enable-composition-webhook-schema-validation` flag, which you may enable to enhance the developer experience. By enabling this flag, you gain a fast feedback loop during the composition crafting process, leading to more efficient and productive development.
 
-### Patching Tips
+### Patching tips
 
-#### 1. Formatting and alignment
+#### Formatting and alignment
 
-Always ensure that `patches` are aligned with `-base` in your manifests. If you are debugging a composition because its not behaving as expected, just like an "off by one" coding error, forgetting proper indention is a common error--and then your patches aren't even defined and applied correctly.
+Always ensure `patches` align with `-base` in your manifests. Forgetting proper indention is a common error, causing your patches to apply incorrectly.
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -158,9 +158,9 @@ spec:
         ...
 ```
 
-#### 2. Patch policy
+#### Patch policy
 
-Policy can be used to make the patch Required (`fromFieldPath: Required`) and set mergeOptions (`keepMapValues: true`) when patching arrays or maps. In the example below, we're patching an array to a property on a bucket.
+Patch policy can make the patch Required (`fromFieldPath: Required`) and set `mergeOptions` (`keepMapValues: true`) when patching arrays or maps. The example below demonstrates patching an array to a property on a bucket.
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -183,11 +183,11 @@ spec:
               keepMapValues: true
 ```
 
-#### 3. Propogating data between managed resources
+#### Propagate data between managed resources
 
-One of the common jobs of composition authors is to exchange data between managed resources in a composition. Whereas the convential use case for patches is to patch from a `spec` supplied by a resource claim to a composed managed resource in a composition, this method of patching is for passing data between two sibling managed resources. To do this, you must publish your desired field from a source managed resource to a custom composite resource `status` field. You can then consume data from this `status` field by a target managed resource.
+One of the common jobs of composition authors is to exchange data between managed resources in a composition. The conventional use case for patches is to patch from a `spec` supplied by a resource claim to a composed managed resource in a composition. You can also patch to pass data between two sibling managed resources. To do this, you must publish your desired field from a source managed resource to a custom composite resource `status` field. You can then consume data from this `status` field by a target managed resource.
 
-In order for the below example to work, the status property (status.eks.oidc) must be defined for this composite resource, which must be done in the XRD.
+In order for the below example to work, the status property (status.eks.oidc) exists in the schema of the resource (in the XRD).
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -203,7 +203,7 @@ spec:
           ....
           status:
             properties:
-              # We define this status field for the composite resource here.
+              # We define this status field for the composite resource.
               eks:
                 description: Freeform field containing status information for eks
                 type: object
@@ -211,7 +211,7 @@ spec:
             type: object
 ```
 
-After you've added the status field to the XRD, you can use it to patch in your composition. This is able to be done because, just like in Kubernetes, every Crossplane object has a nested object field called `status`. In this example below, you can see how we propogate data emitted from one managed resouce (a cluster resource) to another managed resource in the composition (an OIDC Provider). 
+After you've added the status field to the XRD, you can use it to patch in your composition. Just like in Kubernetes, every Crossplane object has a nested object field called `status`. You can see how to propagate data emitted from one managed resource (a cluster resource) to another managed resource in the composition (an OIDC Provider). 
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -249,9 +249,9 @@ spec:
           toFieldPath: spec.forProvider.url
 ```
 
-#### 4. Block composition rendering
+#### Block composition rendering
 
-A `Required` field will prevent a composition from rendering until it's available. 
+A `Required` field prevents a composition from rendering until it's available. 
 
 ```yaml
 - name: oidcProvider
@@ -267,15 +267,15 @@ A `Required` field will prevent a composition from rendering until it's availabl
             fromFieldPath: Required
 ```
 
-In the example above, making this a required patch means the `oidcProvider` resource won't render unless the composite is tested with a live ProviderConfig in a fully configured controlplane. This impacts how you would go about validating and testing the composite output prior to publishing it in a configuration package.
+The preceding example makes this a required patch. This means the `oidcProvider` resource fails to render unless you test the composite with a live ProviderConfig in a fully configured control plane. This impacts how you would go about validating and testing the composite output before publishing it in a configuration package.
 
 {{< hint "note" >}}
 You configure whether a field is required in an XRD, not the composition
 {{< /hint >}}
 
-#### 5. Label Selector matching
+#### Label selector matching
 
-Label Selectors will match at the cluster-level on CRDs, so ensure labels on any managed resources are unique.
+Label Selectors match at the cluster-level on CRDs, so ensure labels on any managed resources are unique.
 
 ```yaml
 policyArnSelector:
@@ -287,9 +287,9 @@ policyArnSelector:
     role: core-ecr
 ```
 
-#### 6. Use patchsets
+#### Use patchSets
 
-Use patchSets for repetitive patching and keep Compositions from becoming bloated. In the example below, you can see a `patchSet` declaration in the spec of the composition, and then that patch is reused across multiple composed resources.
+Use `patchSets` for repetitive patching and keep Compositions from becoming bloated. In the example below, you can see a `patchSet` declaration in the spec of the composition, and then multiple composed resources reference it.
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -324,11 +324,11 @@ spec:
           patchSetName: network-id
 ```
 
-### Other Best Practices
+### Other best practices
 
-#### 1. Label your compositions
+#### Label your compositions
 
-Always label the composition in `metadata` for future selection. Composition names must match the DNS spec. Always including the full group name (as below) is a convention, not a requirement. The name has a limit on the length (63-character). The group can be omitted if the name gets too long, but each composition must have a unique name on the cluster.
+Always label the composition in `metadata` for future selection. Composition names must match the DNS spec. Always including the full group name (as below) is a convention. The name has a limit on the length (63-character). The group is omissible if the name gets too long, but each composition must have a unique name on the cluster.
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -342,9 +342,9 @@ spec:
   ...
 ```
 
-#### 2. Name composed resources
+#### Name composed resources
 
-Always name Composed Resources in the resources array of a composition. This makes it easier to debug compositions when they're running because events will print out their name, as oppsoed to an index in an array. In the example below, you can see how we've named three composed resources as part of an XEKS composition.
+Always name Composed Resources in the resources array of a composition. It's easier to debug compositions when they're running because events print out their name, as opposed to an index in an array. In the example below, observe three composed resources are part of an `XEKS` composition.
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -382,10 +382,10 @@ spec:
 If you use Kuttl to validate composites, managed resources _must_ be named uniquely. It's sometimes helpful to have a nestable composite which sets this unique name.
 {{< /hint >}}
 
-#### 3. Composing resources from multiple Crossplane providers
+#### Composing resources from multiple Crossplane providers
 
-Be conscious about composing resources from multiple different providers. It's a supported scenario but it brings additional complexity. For example, `Selector` and `References` only work with a single provider today, not with multiple providers.
+Be conscious about composing resources from multiple different providers. It's a supported scenario but it introduces complexity. For example, `Selector` and `References` only work with a single provider today, not with multiple providers.
 
-## Next Steps
+## Next steps
 
 After you've authored your composition, the third step you must take is to package up your API as a configuration. Read [Authoring Configurations]({{< ref "xp-arch-framework/building-apis/building-apis-configurations.md" >}}) to learn about best practices for how to do this.

--- a/content/xp-arch-framework/building-apis/building-apis-configurations.md
+++ b/content/xp-arch-framework/building-apis/building-apis-configurations.md
@@ -4,7 +4,7 @@ weight: 6
 description: "how to build APIs"
 ---
 
-A Control plane configuration is a package that bundles one or more APIs--their definitions (XRDs) and their implementations (compositions). Whereas Crossplane composite resources allow you to define a single API, configurations allow you to bundle a set of related APIs together, version them, and declare their dependencies. Because configurations are packages, they're the output of a build process. Today, that output is an OCI image.
+A Control plane configuration is a package that bundles one or more APIs--their definitions (XRDs) and their implementations (compositions). Whereas Crossplane composite resources allow you to define a single API, configurations allow you to bundle a set of related APIs together. They also allow you to version them and declare their dependencies. Because configurations are packages, they're the output of a build process. Today, that output is an OCI image.
 
 {{< hint "important" >}}
 If you are not already familiar with core Crossplane concepts, we recommend first reading the upstream [Crossplane concepts](https://docs.crossplane.io/master/concepts/) documentation.
@@ -12,11 +12,11 @@ If you are not already familiar with core Crossplane concepts, we recommend firs
 
 ## When to create a control plane configuration
 
-**Always!** As a best practice, configurations are the packaging format of choice for delivering **all APIs** to a control plane--even if that's only a single API. You should always use configurations to distribute and install new APIs on a Crossplane instance. 
+**Always!** As a best practice, configurations are the packaging format of choice for delivering **all APIs** to a control plane. Even if that's only a single API, you should always use configurations to distribute and install new APIs on a Crossplane instance. 
 
-## Configuration layout in git
+## Configuration layout in Git
 
-We recommend the definition of your Crossplane configurations to be stored in a git-based version control service. At the root of every Crossplane configuration is a `crossplane.yaml` metadata file. We recommend creating an `apis` folder next and placing all your API definitions in that folder. Each API (XRD and its compositions) should go in its own folder. The folder structure we recommend looks like this:
+It's recommended you keep the definitions of your Crossplane configurations in a Git-based version control service. At the root of every Crossplane configuration is a `crossplane.yaml` metadata file. It's recommended you create an `apis` folder next and place all your API definitions in that folder. Each API (XRD and its compositions) should go in its own folder. The folder structure should look like this:
 
 ```bash
 .
@@ -31,9 +31,9 @@ We recommend the definition of your Crossplane configurations to be stored in a 
     └── ...
 ```
 
-This structure works well for basic APIs that have a definition (XRD) and single implementation (1 composition) that are all defined locally in the folder structure and will be bundled in this configuration. 
+This structure works well for basic APIs that have a definition (XRD) and single implementation (1 composition). They're all defined locally in the directory structure and bundled in a single configuration. 
 
-We recommend this folder structure because it improves human readability, not because Crossplane depends on a certain folder structure. The folder structure doesn't affect Crossplane’s ability to build a package since all .YAML files are flattened during the build process. 
+It's a best practice it improves human readability, not because Crossplane depends on a certain folder structure. The folder structure doesn't affect Crossplane's ability to build a package since all .YAML files get flattened during the build process. 
 
 {{< hint "important" >}}
 👉 Be careful to avoid placing .YAML files in your configuration's directory tree that you **don't** want Crossplane to parse. This can cause builds to unintentionally break because Crossplane will attempt to ingest **all** .YAML files.
@@ -64,7 +64,7 @@ $(UP) xpkg build \
 
 ### Advanced layout: Nested compositions
 
-As we discuss in docs for building compositions, compositions can be nested and/or they can have multiple implementations. The same folder structure still applies and would look like the following:
+As discussed in docs for building compositions, compositions are nestable and/or they can have multiple implementations. The same folder structure still applies and would look like the following:
 
 ```bash
 .
@@ -87,9 +87,9 @@ As we discuss in docs for building compositions, compositions can be nested and/
 
 ## Configuration dependencies
 
-A configuration can declare dependencies as part of its definition. This is done in the `spec.dependsOn` field in the `crossplane.yaml`. This is handy for two reasons:
+A configuration can declare dependencies as part of its definition. Declare them in the `spec.dependsOn` field in the `crossplane.yaml`. It's handy for two reasons:
 
-1. **Provider resolution**: you can declare which Crossplane provider versions your configuration depends on (say, if it uses an API version of a managed resource that changed from provider-aws v0.33.0 to provider-aws v0.34.0). This ensures your configuration will have the provider and version it needs in order to operate.
+1. **Provider resolution**: you can declare which Crossplane provider versions your configuration depends on (say, if it uses an API version of a managed resource that changed from provider-aws v0.33.0 to provider-aws v0.34.0). This ensures your configuration have the provider and version it needs to operate.
 2. **use other configurations**: you can declare dependencies on other configurations. This enables you to chain dependencies together (discussed more below). 
 
 Declaring dependencies for a configuration looks like this:
@@ -113,37 +113,37 @@ Removing a dependency from your configuration's `dependsOn` list does not automa
 
 ### Chain configurations together
 
-Because configurations enable you to declare dependencies on other configurations, you can use a building blocks pattern: rather than put every API that you want to create into a single configuration OR duplicate definitions of APIs across multiple configurations, you can improve reusability by logically structuring your configurations and composing them into larger or smaller packages, depending on your need.
+Because configurations enable you to declare dependencies on other configurations, you can use a building blocks pattern. Rather than put every API into a single configuration OR duplicate definitions of APIs across multiple configurations, you can improve reuse. Logically structure your configurations and compose them into larger or smaller packages, depending on your need.
 
 For example, you could define configurations based on the scope of the APIs:
 
-- **myorg-configuration-networking** defines a set of APIs that your organization will use for provisioning networking resources
-- **myorg-configuration-compute** defines a set of APIs that your organization will use for provisioning compute resources (VMs, clusters, etc).
-- **myorg-configuration-storage** defines a set of APIs that your organization will use for provisioning storage resources (buckets, databases, etc).
-- **myorg-configuration-iam** defines a set of APIs that your organization will use for provisioning identity-related resources (roles, policies, etc).
-- **myorg-configuration-serverless** defines a set of APIs that your organization will use for provisioning serverless-related resources (functions, etc). 
+- **myorg-configuration-networking** defines a set of APIs that your organization uses for provisioning networking resources
+- **myorg-configuration-compute** defines a set of APIs that your organization uses for provisioning compute resources (virtual machines, clusters, etc).
+- **myorg-configuration-storage** defines a set of APIs that your organization uses for provisioning storage resources (buckets, databases, etc).
+- **myorg-configuration-iam** defines a set of APIs that your organization uses for provisioning identity-related resources (roles, policies, etc).
+- **myorg-configuration-serverless** defines a set of APIs that your organization uses for provisioning serverless-related resources (functions, etc). 
 
 This would allow you to create configurations that selectively bundle some--but not all--of these APIs into higher-level configurations.
 
-- **Myorg-config-team1** that has a dependency on _myorg-configuration-networking_ and _myorg-configuration-compute_.
-- **Myorg-config-team2** that has a dependency on _myorg-configuration-serverless_ and _myorg-configuration-storage_.
+- **myorg-configuration-team1** that has a dependency on _myorg-configuration-networking_ and _myorg-configuration-compute_.
+- **myorg-configuration-team2** that has a dependency on _myorg-configuration-serverless_ and _myorg-configuration-storage_.
 
-Another pattern that you can apply to configuration packages and dependency chaining is to have one platform team own the baseline set of APIs that exists on all control planes for your organization, then you can have service or pattern teams build APIs for specific services that sit above the baseline set of APIs.
+Another pattern that you can apply to configuration packages and dependency chaining is to have a bootstrap plus pattern approach. One platform team own the baseline set of APIs that exists on all control planes for your organization. Another service or pattern team builds APIs for specific services that sit on top of the baseline set of APIs.
 
 ## Build configurations
 
-Because configurations are a package, they need to be built before they can be installed into a Crossplane. 
+Because configurations are a package, you must build them before you install into your Crossplane. 
 
 ### The build process
 
-Configurations can be built using the up CLI's [xpkg build]({{< ref "cli/command-reference.md#xpkg-build" >}}) command. You should execute this command in the root folder of your configuration--wherever your `crossplane.yaml` is located:
+Build configurations using the _up_ CLI's [xpkg build]({{< ref "cli/command-reference.md#xpkg-build" >}}) command. You should run this command in the root folder of your configuration--wherever your `crossplane.yaml` is:
 
 ```bash
 $ up xpkg build -o my-configuration-package.xpkg
 xpkg saved to my-configuration-package.xpkg
 ```
 
-Once you've built a configuration package, you can push it to any OCI-compliant registry, such as the [Upbound Marketplace](https://marketplace.upbound.io) or your own container registry. You can use up CLI's [xpkg push]({{< ref "cli/command-reference.md#xpkg-push" >}}) command to do this:
+Once you've built a configuration package, push it to any OCI-compliant registry, such as the [Upbound Marketplace](https://marketplace.upbound.io) or your own container registry. You can use up CLI's [xpkg push]({{< ref "cli/command-reference.md#xpkg-push" >}}) command to do this:
 
 ```bash
 $ up xpkg push my-org/my-configuration-packagev0.0.1 -f my-configuration-package.xpkg
@@ -152,9 +152,9 @@ xpkg pushed to my-org/my-configuration-packagev0.0.1
 
 ### Set up a build pipeline with GitHub
 
-We recommend storing your configuration definition in a version controlled environment and to set up a build pipeline that will automatically create a new version of your configuration when a new commit is pushed. If you are using a version control service such as GitHub, you can configure a [GitHub Action](https://docs.github.com/en/actions) on the git repo which hosts your configuration definition. 
+It's recommended you store your configuration definition in a version controlled environment and set up a build pipeline. The pipeline should automatically create a new version of your configuration when a new commit merges. If you are using a version control service such as GitHub, you can configure a [GitHub Action](https://docs.github.com/en/actions) on the Git repository.
 
-Below is a sample workflow file that uses a GitHub Action, [crossplane-contrib/xpkg-action](https://github.com/crossplane-contrib/xpkg-action), which you can use as the basis for your own GitHub Action and can be tweaked according to your needs:
+Below is a sample workflow file that uses a GitHub Action, [crossplane-contrib/xpkg-action](https://github.com/crossplane-contrib/xpkg-action). You can use it as the basis for your own GitHub Action, tweaked according to your needs:
 
 ```yaml
 name: CI
@@ -219,10 +219,10 @@ spec:
     - name: registry-key
 ```
 
-Because Configurations are just another Kubernetes object, you can apply GitOps patterns and tooling to continuously monitor a repo source and deploy your desired configuration to your control plane. We recommend establishing an GitOps-based automated process to apply configurations to your control planes, which is described and implemented in the [baseline control plane architecture]({{< ref "xp-arch-framework/architecture/architecture-baseline-single" >}}).
+Because Configurations are just another Kubernetes object, you can apply GitOps patterns and tooling to it. Use GitOps tools to continuously watch a repository source and deploy your desired configuration to your control plane. It's recommended you establish an GitOps-based automated process to apply configurations to your control planes. Read the [baseline control plane architecture]({{< ref "xp-arch-framework/architecture/architecture-baseline-single" >}}) to learn how.
 
-In the example above, we recommend adding `commonLabels` to your package because it makes it easier to introduce `compositionRevisions` with autogenerated labels from this field.
+In the preceding example, it's recommended you add `commonLabels` to your package. It makes it easier to introduce `compositionRevisions` with auto generated labels from this field.
 
-## Next Steps
+## Next steps
 
 After you've learned how to package and deploy your APIs, you should think about how to architect a production-ready solution on Crossplane. Read [Architecture]({{< ref "xp-arch-framework/architecture/architecture-baseline-single" >}}) to learn about best practices for how to do this.

--- a/content/xp-arch-framework/building-apis/building-apis-xrds.md
+++ b/content/xp-arch-framework/building-apis/building-apis-xrds.md
@@ -4,7 +4,7 @@ weight: 4
 description: "how to build APIs"
 ---
 
-[Composite resource definitions (XRDs)](https://docs.crossplane.io/master/concepts/composition/#compositeresourcedefinitions) define the type and schema of your composite resource (XR). Think of the XRD as the object that defines the **shape** of your API. While the fields you choose to define in the `spec` of your XRD are highly dependent on the use case you’re trying to accomplish, there are a general set of best practices you can apply to help you approach how to define an XRD.
+[Composite resource definitions (XRDs)](https://docs.crossplane.io/master/concepts/composition/#compositeresourcedefinitions) define the type and schema of your composite resource (XR). Think of the XRD as the object that defines the **shape** of your API. The fields you choose to define in the `spec` of your XRD are highly dependent on your use case. Below are best practices you can apply to help you approach how to define an XRD.
 
 {{< hint "important" >}}
 If you are not already familiar with core Crossplane concepts, we recommend first reading the upstream [Crossplane concepts](https://docs.crossplane.io/master/concepts/) documentation.
@@ -12,14 +12,14 @@ If you are not already familiar with core Crossplane concepts, we recommend firs
 
 ## Purpose
 
-If you haven't read and gone through the framework's [self-evaluation]({{< ref "xp-arch-framework/self-eval.md" >}}) exercise, we recommend you do that now. It's difficult to build a custom API without knowing who you are building it for and why you're building it. If you have an understanding of how you're building the custom API for and what inputs (if any) you want your consumers to have, the next questions you need to figure out are:
+If you haven't read and gone through the framework's [self-evaluation]({{< ref "xp-arch-framework/self-eval.md" >}}) exercise, it's recommended you do that now. It's difficult to build a custom API without knowing who you are building it for and why you're building it. First, figure this out. The next questions you need to figure out are:
 
 - What managed resources do you want to compose together as part of this API?
-- For each managed resource you want to compose, which fields are required?
+- For each managed resource you want to compose, what are the required fields?
 
 ### Which managed resources to compose
 
-Most Crossplane providers have a number of different managed resources that map to appropriate APIs to manage a particular set of infrastucture or resources.
+Most Crossplane providers have lots of different managed resources that map to appropriate APIs to manage a particular set of infrastructure or resources.
 
 {{< table "table table-sm" >}}
 | Generic | Crossplane provider-aws | AWS infrastructure |
@@ -28,40 +28,48 @@ Most Crossplane providers have a number of different managed resources that map 
 | resource-2 | [`SecurityGroup`](https://marketplace.upbound.io/providers/upbound/provider-aws-ec2/latest/resources/ec2.aws.upbound.io/SecurityGroup/v1beta1) | A Security Group | 
 {{< /table >}}
 
-When you create some infrastructure in a cloud service, sometimes that infrastructure maps to a single API (such as an S3 bucket) and other times it actually maps to multiple APIs. For example, if you create an EKS cluster in AWS, there is an AWS cluster object, some IAM rules, a NodeGroup, network settings, and more; this is multiple APIs and multiple objects that get created. 
+When you create infrastructure in a cloud service, sometimes that infrastructure maps to a single API (such as an S3 bucket). Other times it actually maps to multiple APIs. For example, when you create an EKS cluster in AWS, these objects get created: 
+
+- an AWS cluster object
+- some IAM rules
+- a NodeGroup
+- network settings
+- and more
+
+Multiple APIs get called and multiple objects get created. 
 
 {{< hint "tip" >}}
 If you are coming from traditional Infrastructure as Code (IaC) tooling such as Terraform or AWS CloudFormation, these tools also have resource representation that maps to underlying APIs in a provider. These IaC tool resources usually map one-to-one to equivalent Crossplane provider managed resources. You can use this to inform which Crossplane managed resources you need to compose. 
 {{< /hint >}}
 
-If you don't have existing IaC tooling definitions to inform which resources you need to compose, you can use the [Upbound Marketplace’s](https://marketplace.upbound.io/) API documentation feature. In the Marketplace, search for a resource you want to create. Within that resource's API documentation, under the `spec.forProvider` struct, look for properties that have a naming pattern like `<resource>Ref` or `<resource>IdSelector`. These are properties which may indicate that, in order for your desired resource to be created, you may need to provide references to _other_ resources. Be advised, this tip is a heuristic, not a firm requirement.
+Use the [Upbound Marketplace's](https://marketplace.upbound.io/) API documentation feature. In the Marketplace, search for a resource you want to create. Within that resource's API documentation, under the `spec.forProvider` struct, look for properties that have a naming pattern like `<resource>Ref` or `<resource>IdSelector`. Those properties may communicate that, in order for your desired resource to create, you may need to provide references to _other_ resources. This tip is a heuristic, not a firm rule.
 
-As an example, consider the provider-aws `Instance` resource for an EC2 Instance. You can see below there is a reference to a networkInterface, indicating this is another resource you may choose to create in Crossplane and then reference in your Instance resource.
+As an example, consider the provider-aws `Instance` resource for an EC2 Instance. You can see below there is a reference to a `networkInterface`. This points to another resource you may choose to create in Crossplane and then reference in your Instance resource.
 
 {{<img src="xp-arch-framework/images/instance-nw-interface.png" alt="Parameters on an AWS EC2 instance" size="small" quality="100">}}
 
 ### Required fields for composed resources
 
-Two reasons it's important to know which fields are required in the MRs you want to compose are:
+Two reasons it's important to know the required fields in the managed resources you want to compose are:
 
 1. There's a high likelihood you want to either expose or let your consumers influence indirectly these fields in your API
-2. Composite Resources ultimately instantiate MRs, so you need to create valid MRs in order for your Composite Resource to create successfully.
+2. Composite Resources result in instantiated managed resources. You need to create valid managed resources in order for your composite resource to create.
 
-Use the [Upbound Marketplace’s](https://marketplace.upbound.io/) API documentation feature to see which fields are required or optional under the `spec.forProvider`. For example, notice in the [AWS EKS Cluster](https://marketplace.upbound.io/providers/upbound/provider-aws-eks/latest/resources/eks.aws.upbound.io/Cluster/v1beta1) resource API documentation how `region` is required whereas `version` isn't.
+Use the [Upbound Marketplace's](https://marketplace.upbound.io/) API documentation feature to see the required fields under the `spec.forProvider`. For example, notice in the [AWS EKS Cluster](https://marketplace.upbound.io/providers/upbound/provider-aws-eks/latest/resources/eks.aws.upbound.io/Cluster/v1beta1) resource API documentation how `region` has a "required" label whereas `version` isn't.
 
-{{<img src="xp-arch-framework/images/eks-required-fields.png" alt="Which fields are required for EKS cluster" size="small" quality="100">}}
+{{<img src="xp-arch-framework/images/eks-required-fields.png" alt="The required fields for EKS cluster" size="small" quality="100">}}
 
-Sometimes a managed resource will have fields that need to have a value but it's not explicitly marked as `required`. For example, the [AWS Lambda Function](https://marketplace.upbound.io/providers/upbound/provider-aws-lambda/latest/resources/lambda.aws.upbound.io/Function/v1beta1) resource API documentation stipulates that “filename, image_uri, or s3_bucket must be specified”, yet none of those fields individually are marked required. It's helpful to look at resources `Examples` in the Upbound Marketplace, because these examples demonstrate configs for MRs that have been verified to successfully create.
+Sometimes a managed resource has fields that need to have a value but it's not explicitly marked as `required`. For example, consider the [AWS Lambda Function](https://marketplace.upbound.io/providers/upbound/provider-aws-lambda/latest/resources/lambda.aws.upbound.io/Function/v1beta1) resource API documentation. It stipulates that `filename, image_uri, or s3_bucket must be specified`, yet none of those fields have a "required" label. It's helpful to look at a resource's "Examples" tab in the Upbound Marketplace. Examples show verified configurations for managed resources.
 
 {{< hint "tip" >}}
-Fields that are required in order for an MR to successfully create usually indicate important details that dramatically impact what gets created. Consider whether these fields should be inputs directly supplied by your API’s consumers, whether it should be influenced by inputs provided by your API’s consumers, or whether they have no business influencing its value at all.
+Fields that are required in order for an MR to successfully create usually indicate important details that dramatically impact what gets created. Consider whether these fields should be inputs directly supplied by your API's consumers, whether it should be influenced by inputs provided by your API's consumers, or whether they have no business influencing its value at all.
 {{< /hint >}}
 
 ## Authoring an XRD
 
 ### Scaffolding an XRD
 
-XRDs follow the [OpenAPI](https://swagger.io/specification/) “structural schema”. Below is boilerplate .YAML that you can use to scaffold the start of an XRD.
+XRDs follow the [OpenAPI](https://swagger.io/specification/) "structural schema." Below is boilerplate .YAML that you can use to scaffold the start of an XRD.
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -99,19 +107,19 @@ spec:
                 <todo>
 ```
 
-In your XRD, you will want to give your Composite Resource a name and update the API group it should be served from. The scaffold above also assumes you want this Composite Resource to be claimable. If you don’t want to allow users to create claims against this Composite Resource, omit the `claimNames` field.
+In your XRD, you should give your Composite Resource a name and update the API group. The preceding scaffold also assumes you want this Composite Resource to be claimable. If you don't want to allow users to create claims against this Composite Resource, omit the `claimNames` field.
 
 {{< hint "important" >}}
 **Should your composite resource be claimable?** In most circumstances, the answer is "yes". Crossplane composite resources are cluster-scoped objects, which means they're not associated with any given namespace in your control plane. By making a composite resource claimable, this enables you to restrict users to different namespaces in your control plane and thereby improve isolation between them. To learn more, read the [architecture]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md#tenancy-on-your-control-plane" >}}) guide.
 {{< /hint >}}
 
-### Authoring Best Practices
+### Authoring best practices
 
 The following are some other best practices to abide by as you author new XRDs:
 
 #### Inputs belong in spec.properties.parameters
 
-All of the inputs you want to provide as part of your API belong in your XRD's `spec.properties.parameters` stanza, as seen in the example below.
+All the inputs you want to provide as part of your API belong in your XRD's `spec.properties.parameters` stanza, as seen in the example below.
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -144,13 +152,13 @@ spec:
 
 The OpenAPI v3 [data models](https://swagger.io/docs/specification/data-models/) define the types and values available for you to use as part of defining your XRD.
 
-#### Comply with OpenAPI v3 data types
+#### Use OpenAPI v3 data types
 
 The OpenAPI v3 [data types](https://swagger.io/docs/specification/data-models/data-types/) define the value types available for you to use as part of your schema.
 
 #### Use enums for static options
 
-We recommend using [Enums](https://swagger.io/docs/specification/data-models/enums/) for static options for field value. For example, if you have field called `environment` and there are a defined list of options for your users to choose from:
+It's recommended you use [Enums](https://swagger.io/docs/specification/data-models/enums/) for static options for field value. For example, if you have field called `environment` and there are a defined list of options for your users to choose from:
 
 ```yaml
 environment:
@@ -160,7 +168,7 @@ type: string
 
 #### String validation
 
-We recommend using `pattern` for complex string validations. For example:
+It's recommended you use `pattern` for complex string validations. For example:
 
 ```yaml
 teamEmailAddress:
@@ -170,11 +178,11 @@ type: string
 
 ### XRD status
 
-The `spec.status` field of your XRD is a useful way to exchange data between various Crossplane resources. In order to patch a value from one Crossplane resource to another, you can publish and consume values via an XRD's status, which means the XRD must first _define_ the status field. Patching is a concept relevant to compositions and is discussed in detail later for how to do this.
+The `spec.status` field of your XRD is a useful way to exchange data between various Crossplane resources. To patch a value from one Crossplane resource to another, you can publish and consume values via an XRD's status. To do so, your XRD must first _define_ the status field. Patching is a concept relevant to compositions; it's discussed in detail later for how to do this.
 
 ## Versioning
 
-Over the lifetime of your custom API, there is a chance the shape of the API could change and you could introduce breaking changes. Crossplane has a built-in capability to help with this. The scaffolding above recommends a boilerplate version named `v1alpha1`. Notice the `versions` field is an array, so you can declare multiple versions of your API definition in the XRD. Crossplane doesn't allow _serving_ multiple versions. Meaning, once v1alpha2 goes live, all of the composites will be force-migrated to that version:
+Over the lifetime of your custom API, there is a chance the shape of the API could change and you could introduce breaking changes. Crossplane has a built-in capability to help with this. The preceding scaffolding recommends a boilerplate version named `v1alpha1`. Notice the `versions` field is an array, so you can declare multiple versions of your API definition in the XRD. Crossplane doesn't allow _serving_ multiple versions. Meaning, once v1alpha2 goes live, all the composites are force-migrated to that version:
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -194,7 +202,7 @@ spec:
       ...
 ```
 
-Note this is just the definition portion of your new API version; you also need to create new compositions that implement the new version. Read [Authoring Compositions]({{< ref "xp-arch-framework/building-apis/building-apis-compositions.md" >}}) to learn how to do that.
+Note the preceding example is just the definition part of your new API version. You also need to create new compositions that serve the implementation the new version. Read [Authoring Compositions]({{< ref "xp-arch-framework/building-apis/building-apis-compositions.md" >}}) to learn how to do that.
 
 ### Converting resources between XRD versions
 
@@ -210,6 +218,6 @@ spec:
       ...
 ```
 
-## Next Steps
+## Next steps
 
 Defining an XRD is half the equation for building a custom API. The other important steps is to define a composition which implements the definition contained in your XRD. Read [Authoring Compositions]({{< ref "xp-arch-framework/building-apis/building-apis-compositions.md" >}}) to learn how to do that.

--- a/content/xp-arch-framework/interface-integrations/_index.md
+++ b/content/xp-arch-framework/interface-integrations/_index.md
@@ -4,7 +4,7 @@ weight: 40
 description: "A guide for how to integrate control planes with a variety of interfaces"
 ---
 
-Crossplane sits at the core of your platform. As a result, there are about six areas you may need to think about integrating with. We've broken integrations into the following:
+Crossplane sits at the core of your platform. As a result, there are about six areas you may need to think about integrating with. The integrations into grouped into following:
 
 - [Platform frontends]({{< ref "xp-arch-framework/interface-integrations/platform-frontends.md" >}})
 - [Git and GitOps]({{< ref "xp-arch-framework/interface-integrations/git-and-gitops.md" >}})
@@ -15,4 +15,4 @@ Crossplane sits at the core of your platform. As a result, there are about six a
 
 ## Use the power of the Kubernetes ecosystem
 
-Crossplane has built-in capabilities for some of these areas that you can use out-of-the-box (such as secrets management). For other areas, it's up to users to bring third-party toolchains to integrate with Crossplane and address the particular use case. Because Crossplane exists in the Kubernetes ecosystem, users oftentimes find value in being able to reuse familiar Kubernetes tooling with Crossplane--you can use this to your advantage. In this framework, we will provide guidance for how to leverage built-in functionality where present, and integrate Crossplane with popular third-party tools when necessary.
+Crossplane has built-in capabilities for some of these areas that you can use out-of-the-box (such as secrets management). For other areas, it's up to users to bring third-party tool chains to integrate with Crossplane and address the particular use case. Because Crossplane exists in the Kubernetes ecosystem, users oftentimes find value in being able to reuse familiar Kubernetes tooling with Crossplane. You can use this to your advantage. This framework provides guidance for how to leverage built-in Crossplane capabilities where present, and integrate Crossplane with popular third-party tools when necessary.

--- a/content/xp-arch-framework/interface-integrations/git-and-gitops.md
+++ b/content/xp-arch-framework/interface-integrations/git-and-gitops.md
@@ -38,7 +38,7 @@ Argo CD is a project that enables GitOps by implementing an `Application` resour
 
 #### Argo and single control plane
 
-In the case where you're running only a single control plane, it's easiest to co-locate Argo inside the cluster where Crossplane is running. After installing Argo, you need to configure it by defining a new `Application` that represents your control plane and a source to pull from.
+If you're running only a single control plane, it's easiest to co-locate Argo inside the cluster where Crossplane is running. After installing Argo, you need to configure it by defining a new `Application` that represents your control plane and a source to pull from.
 
 ```yaml
 #controlplane-1.yaml

--- a/content/xp-arch-framework/interface-integrations/git-and-gitops.md
+++ b/content/xp-arch-framework/interface-integrations/git-and-gitops.md
@@ -4,43 +4,41 @@ weight: 2
 description: "A guide for how to integrate control planes with a variety of interfaces"
 ---
 
-GitOps is an approach for managing a system by declaratively describing desired resources' configurations in git and using controllers to realize the desired state. Crossplane is completely compatible with this pattern and we strongly recommend customers implement GitOps in their platforms built on Crossplane. 
+GitOps is an approach for managing a system by declaratively describing desired resources' configurations in Git and using controllers to realize the desired state. Crossplane is compatible with this pattern and it's strongly recommended you integrate GitOps in your platforms built on Crossplane. 
 
 ## Git and Crossplane
 
-Here are three ways you should plan for integrating git with Crossplane:
+### Use Git for storing your custom APIs
 
-### 1. Use git for storing your custom APIs
-
-Building custom APIs with Crossplane doesn't require users to write code, but you still need to write configurations and definitions as YAML. As with traditional software development, you should store your custom API definitions in a version control system, such as git. You should have an automated build pipeline set up with your git repo to package your APIs in a configuration package, then install the package on your control plane.
+Building custom APIs with Crossplane doesn't require users to write code, but you still need to write configurations and definitions as YAML. As with traditional software development, you should store your custom API definitions in a version control system, such as Git. Create an automated build pipeline with your Git repository to package your APIs in a configuration package, then install the package on your control plane.
 
 {{< hint "note" >}}
 Learn more about how to sturcture your repo and define your APIs in the [Building APIs]({{< ref "xp-arch-framework/building-apis/" >}}) section of this framework.
 {{< /hint >}}
 
-### 2. Use git as an interface to invoking your control plane's APIs 
+### Use Git as an interface to invoking your control plane's APIs 
 
-When users think of `GitOps` with Crossplane, its usually in this regard: whenever a user needs a resource from your control plane, a claim should be created. Whether the claim is created directly by the requesting user or there is a [platform frontend]({{< ref "xp-arch-framework/interface-integrations/platform-frontends.md" >}}) that collects information from a user and creates a claim in the background, claims are the Kubernetes-native way to interact with your API.
+Whenever a user needs a resource from your control plane, a claim must get created. Whether the claim gets created directly by the requesting user or there is a [platform frontend]({{< ref "xp-arch-framework/interface-integrations/platform-frontends.md" >}}) that collects information from a user and creates a claim in the background, claims are the Kubernetes-native way to interact with your API.
 
-Claims themselves are resources with a configuration (a `spec`), and as such can and should be declaratively stored in git. We recommend storing claims in a git repo and then using a GitOps engine such as Argo or Flux--described later on below--to deliver the claims to your control plane.
+Claims themselves are resources with a configuration (a `spec`), and as such can and should be declaratively stored in Git. It's recommended you store claims in a Git repository. Then, use a GitOps engine such as Argo or Flux--described later on below--to deliver the claims to your control plane.
 
-### 3. Use git to store the infrastructure definition that backs your control plane
+### Use Git to store the infrastructure definition that backs your control plane
 
-Your control plane itself is infrastructure, and as such should ideally be defined in git. A [chicken or the egg](https://en.wikipedia.org/wiki/Chicken_or_the_egg) problem is commonly brought up by platform teams who want to use Crossplane to drive their entire platform. We address this in the [single control plane baseline architecture]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md#control-plane-causality-dilemma" >}}) portion of this framework.
+Your control plane itself is infrastructure, so its definition should live in Git. A [chicken or the egg](https://en.wikipedia.org/wiki/Chicken_or_the_egg) problem is commonly brought up by platform teams who want to use Crossplane to drive their entire platform. Consult the [single control plane baseline architecture]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md#control-plane-causality-dilemma" >}}) page for guidance on this topic.
 
 ## GitOps and Crossplane 
 
-[Argo](https://argo-cd.readthedocs.io/en/stable/) and [Flux](https://fluxcd.io/) are two examples of projects in the Kubernetes ecosystem that you can use in tandem with Crossplane to achieve GitOps flows. They're also the most commonly chosen tools to accomplish this job, so we'll provide specific recommendations for integrating these with Crossplane below. 
+[Argo](https://argo-cd.readthedocs.io/en/stable/) and [Flux](https://fluxcd.io/) are two examples of projects in the Kubernetes ecosystem that you can use in tandem with Crossplane to achieve GitOps flows. They're also the most commonly chosen tools for this job. Below are specific recommendations for integrating these with Crossplane below. 
 
 ### Integrate Crossplane with Argo
 
-Argo CD is a project that enables GitOps by implementing an `Application` resource, which provides a declarative approach to managing config management tooling for Kubernetes resources (for example, Helm and Kustomize) and a controller for handling the reconciliation loop for syncing the resources into the cluster (updating the live state to match the desired state).
+Argo CD is a project that enables GitOps by implementing an `Application` resource. This provides a declarative approach to managing configuration management tooling for Kubernetes resources (such as Helm or Kustomize).
 
 {{<img src="xp-arch-framework/images/argo.png" alt="An illustration of Argo" size="small" quality="100">}}
 
 #### Argo and single control plane
 
-In the case where you're running only a single control plane, it's easiest to colocate Argo inside the cluster where Crossplane is running. Once Argo is installed, you need to configure it by defining a new `Application` that represents your control plane and a source to pull from.
+In the case where you're running only a single control plane, it's easiest to co-locate Argo inside the cluster where Crossplane is running. After installing Argo, you need to configure it by defining a new `Application` that represents your control plane and a source to pull from.
 
 ```yaml
 #controlplane-1.yaml
@@ -63,13 +61,14 @@ spec:
     automated: {}
 ```
 
-Based on the recommendations we make for how to [structure your APIs]({{< ref "xp-arch-framework/building-apis/building-apis-configurations.md#configuration-layout-in-git" >}}) in git, be sure to enable [recursive resource detection](https://argo-cd.readthedocs.io/en/stable/user-guide/directory/#enabling-recursive-resource-detection) (as we've demonstrated in the example above).
+Based on the recommendations for how to [structure your APIs]({{< ref "xp-arch-framework/building-apis/building-apis-configurations.md#configuration-layout-in-git" >}}) in Git, be sure to enable [recursive resource detection](https://argo-cd.readthedocs.io/en/stable/user-guide/directory/#enabling-recursive-resource-detection) (as demonstrated in the preceding example).
 
 #### Argo and multi-control plane
 
-Following the same advice as for Flux, in a multi-control plane architecture we recommend deploying Argo as a centralized instance in its own cluster, then register your control planes as external targets. To do this, you will create new `Application` resources in Argo that establish a relationship between a git source and your control planes.
+Its recommended you deploy Argo as a centralized instance in its own cluster to handle a multi-control plane architecture. Then, register your control planes as external targets. To do this, create new `Application` resources in Argo that establish a relationship between a Git source and your control planes.
 
-To configure Argo for deploying to multiple clusters, you need to define a new `Application` for each control plane which represents your control plane and a source to pull from.
+To configure Argo for deploying to multiple clusters, define a new `Application` for each control plane. This represents your control plane and a source to pull from.
+
 ```yaml
 #controlplane-1.yaml
 apiVersion: argoproj.io/v1alpha1
@@ -91,7 +90,7 @@ spec:
     automated: {}
 ```
 
-You will need to configure the `spec.destination.server` to point to the endpoint for your control plane's cluster API server. You will need to [configure credentials](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories) to your repository. For every control plane that you want to register with your central instance of Argo, you will create a new `Application` object as above. 
+You need to configure the `spec.destination.server` to point to the endpoint for your control plane's cluster API server. You need to [configure credentials](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories) to your repository. For every control plane that you want to register with your central Argo, you must create a new `Application` object as in the preceding example. 
 
 ### Integrate Crossplane with Flux
 
@@ -99,14 +98,14 @@ Flux is a set of controllers that keeps Kubernetes clusters in sync with a confi
 
 {{<img src="xp-arch-framework/images/flux.png" alt="An illustration of Flux" size="small" quality="100">}}
 
-If you are using self-hosted Flux, you need to deploy it into a Kubernetes cluster. Once you have installed Flux into a cluster, you will want to configure it in two ways:
+If you are using self-hosted Flux, you need to deploy it into a Kubernetes cluster. Once you have installed Flux into a cluster, you should configure it in two ways:
 
-1. Tell Flux which git sources to pull.
+1. Tell Flux which Git sources to pull.
 2. Tell Flux which clusters to target applying changes to.
 
 #### Flux and single control plane
 
-In the case where you're running only a single control plane, it's easiest to colocate Flux inside the cluster where Crossplane is running. Once Flux is installed, you need to do three things:
+For single control plane scenarios, it's easiest to co-locate Flux inside the cluster where Crossplane is running. After deploying Flux, you need to do three things:
 
 1. Define a `GitRepository` source for each control plane.
 ```yaml
@@ -151,9 +150,9 @@ resources:
 
 #### Flux and multi-control planes
 
-While you _could_ install Flux into one of the clusters where Crossplane has been installed into, our baseline recommendation is to operate a centralized instance of Flux and register your control planes (external to Flux) with it. This approach scales better for users who plan to run several Crossplanes.
+While you _could_ install Flux into one of the clusters alongside Crossplane, it's recommended you create a centralized instance of Flux. Then, register your control planes (external to Flux) with it. This approach scales better for users who plan to run several control planes.
 
-To configure Flux for deploying to multiple clusters, you will need to do the following:
+To configure Flux for deploying to multiple clusters, you need to do the following:
 
 1. Define a `GitRepository` source for _each_ control plane.
 ```yaml
@@ -170,7 +169,7 @@ spec:
   url: https://github.com/yourorg/your-repo
 ```
 
-2. Define a `Kustomization` to tell Flux how frequently you want to pull state from the source and to which target it should sync to. Notice the `kubeconfig.secretRef.name` stanza, which will configure Flux to apply reconcillations on remote clusters--or clusters which Flux is _not_ installed on. This is key to how you use a centralized Flux instance to target multiple clusters. You need to couple this by injecting a secret into the cluster where Flux runs which encapsulates the kuconfig of your control plane.
+2. Define a `Kustomization` to tell Flux how frequently you want to pull state from the source and to which target it should sync to. Notice the `kubeconfig.secretRef.name` stanza, which configures Flux to apply the reconciliation on remote clusters--or clusters which Flux is _not_ installed on. You need to couple this by injecting a secret into the cluster where Flux runs which encapsulates the kubeconfig of your control plane.
 ```yaml
 #xp-kustomization.yaml
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
@@ -199,4 +198,4 @@ resources:
 - xp-kustomization.yaml
 ```
 
-For every new instance of Crossplane that you want to register and set up GitOps flows for with Flux, you will create pairs of files as we demonstrated with `xp-repo.yaml` and `xp-kustomization.yaml` above.
+You must create pairs of `GitRepositories` and `Kusomizaitons` for every new instance of Crossplane that you want to register and set up GitOps flows for with Flux. 

--- a/content/xp-arch-framework/interface-integrations/monitoring-and-observability.md
+++ b/content/xp-arch-framework/interface-integrations/monitoring-and-observability.md
@@ -8,7 +8,7 @@ description: "A guide for how to integrate control planes with monitoring and ob
 This section is under construction - stay tuned for additional guidance and best practices for monitoring & observability with Crossplane.
 {{< /hint >}}
 
-Crossplane is capable of being configured to emit prometheus metrics. After you've enabled metrics emission in Crossplane, you should use a tool to collect and aggregate the logs and metrics that are emitted. If your org is already using one of the many third-party solutions that integrate with Kubernetes for monitoring, such as Datadog, Grafana, or New Relic, you are encouraged to use them. 
+Crossplane is able to emit Prometheus metrics. After you've enabled metrics emission in Crossplane, you should use a tool to collect the logs and metrics. You can then integrate with third-party monitoring solutions such as Datadog, Grafana, or New Relic.
 
 ## Enable metrics for Crossplane
 

--- a/content/xp-arch-framework/interface-integrations/platform-continuity.md
+++ b/content/xp-arch-framework/interface-integrations/platform-continuity.md
@@ -6,21 +6,21 @@ description: "A guide for how to integrate control planes with DR tools"
 
 Platform continuity is a topic that encompasses everything you need to do to keep your platform up and running. This content is currently focused on providing guidance for how to perform disaster recovery with Crossplane.
 
-## Disaster Recovery
+## Disaster recovery
 
-[Velero](https://velero.io/) is a popular open source solution in the Kubernetes ecosystem to safely perform backup and restore operations against Kubernetes cluster resources. We recommend using Velero in any disaster recovery plan for your Crossplane control planes. We will cover best practices for using Velero in the context of Crossplane.
+[Velero](https://velero.io/) is a popular open source solution in the Kubernetes ecosystem to perform backup and restore operations against Kubernetes cluster resources. It's recommended to use Velero in any disaster recovery plan for your Crossplane control planes. This guides covers best practices for using Velero in the context of Crossplane.
 
 ### In the context of Crossplane
 
 Disaster recovery for Crossplane doesn't equal disaster recovery for your business critical state, like database or cloud storage data. It's important to remember:
 
-1. Crossplane is concerned with ensuring the configuration of your resource. 
+1. Crossplane ensures the configuration of your resource. 
 2. Crossplane **isn't concerned** with the _internal_ state of your resources. 
 
-Crossplane is concerned with enforcing two things:
+Crossplane enforces two things:
 
 1. the resources you declared exist.
-2. the configuration of those resources matches what you declared. If it doesn't, it will attempt to reconcile to the desired state.
+2. the configuration of those resources matches what you declared. If it doesn't, it attempts to reconcile to the desired state.
 
 Crossplane **isn't** concerned with the state of what's happening _within_ the resource. For example, consider a CloudSQL instance created with Crossplane using the following manifest:
 
@@ -36,13 +36,13 @@ spec:
         tier: db-f1-micro
 ```
 
-Crossplane will ensure whatever instance gets created in GCP has a disk size of 20 GB and that it uses MySQL version 5.7; it will continuously ensure the configuration of the instance matches these parameters. However, Crossplane has no involvement with what goes on _inside_ the CloudSQL instance. If someone was using this database to store records of users for a line-of-business app, Crossplane is oblivious.
+Crossplane ensures the resource created in GCP has a disk size of 20 GB and it uses MySQL version 5.7. It continuously ensures the configuration of the instance matches these parameters. Crossplane has no involvement with what goes on _inside_ the CloudSQL instance. If someone was using this database to store records of users for a line-of-business app, Crossplane is oblivious.
 
-Likewise, if your control plane fails and goes offline, that doesn't necessarily mean the resources under management by that control plane will be affected--it means the configuration of those resources won't be reconciled while the control plane is offline, so configuration drift could occur. Using the database example above, if the control plane managing the CloudSQL instance fails, that doesn't necessarily mean your database is now offline. 
+Likewise, if your control plane fails and goes offline, that doesn't necessarily mean the resources under management by that control plane does too. It means the configuration of those resources stops reconciling while the control plane is offline, so configuration drift could occur. Using the preceding database example, if the control plane managing the CloudSQL instance fails, that doesn't necessarily mean your database is now offline. 
 
-### What State to Capture vs Exclude
+### What state to capture vs exclude
 
-You should configure Velero to capture state that's only relevant for Crossplane. The following is a sample Velero backup object that illustrates which Kubernetes resources are applicable to be backed up and which ones can be safely excluded:
+You should configure Velero to capture state that's only relevant for Crossplane. The following is a sample Velero backup object that illustrates which Kubernetes resources are applicable for backup and which ones aren't:
 
 ```yaml
 apiVersion: velero.io/v1
@@ -84,15 +84,15 @@ spec:
   ttl: 720h0m0s
  ```
 
- We recommend configuring Velero to store the captured backup state for all your control planes in a single, global bucket or blob.
+It's recommended you configure Velero to store the captured backup state for all your control planes in a single, global bucket or blob.
 
 {{< hint "tip" >}}
 Instead of excluding all other resources, you could include only the resources that you want to backup. However, this would require you to list _all_ resources types--including the CRDs introduced by providers--which isn't possible/feasible. Hence, we recommend doing it the way we show above.
 {{< /hint >}}
 
-### Backup Schedules
+### Backup schedules
 
-We recommend establishing a Velero schedule to periodically take snapshots for each control plane. THe following is a sample Velero schedule object that illustrates a recommended schedule:
+It's recommended you establish a Velero schedule to periodically take snapshots for each control plane. THe following is a sample Velero schedule object that illustrates a recommended schedule:
 
 ```yaml
 apiVersion: velero.io/v1
@@ -136,15 +136,17 @@ spec:
     ttl: 168h0m0s
 ```
 
-For each control plane that you create, create three Velero `Schedule` objects illustrated above with the following schedules:
+For each control plane that you create, create three Velero `Schedule` objects in the preceding examples with the following schedules:
 
+<!-- vale off -->
 - Hourly
 - Daily
 - Weekly
 
-We think this is a good baseline, but you can customize the frequency of the backups according to the Recovery Point Objective (RPO) for your platform. If you need to be able to restore state more frequently, you will want to snapshot more frequently.
+You can customize the frequency of the backups according to the Recovery Point Objective (RPO) for your platform. If you need to be able to restore state more frequently, you must snapshot more frequently.
+<!-- vale on -->
 
-### Restore Control Plane from state
+### Restore control plane from state
 
 To restore backup state into a new cluster:
 
@@ -152,4 +154,4 @@ To restore backup state into a new cluster:
 2. Install Velero and configure it to use the backup data source.
 3. Restore the backed up resources to the new cluster.
 4. Scale up the provider deployments to one in the new cluster.
-5. During the backup and restoration process Velero preserves owner references, resource states, and external names of managed resources. Therefore from here on, the reconciliation process should kick in and proceed as if there were no changes.
+5. During the backup and restoration process Velero preserves owner references, resource states, and external names of managed resources. The reconciliation process should kick in and proceed as if there were no changes.

--- a/content/xp-arch-framework/interface-integrations/platform-frontends.md
+++ b/content/xp-arch-framework/interface-integrations/platform-frontends.md
@@ -6,20 +6,20 @@ description: "A guide for how to integrate control planes with a variety of inte
 
 Just like Kubernetes, the default interface to a new Crossplane instance is the [Kubernetes-based API](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/), typically interacted with via a tool like [kubectl](https://kubernetes.io/docs/reference/kubectl/).
 
-Most users don't want to directly expose their Crossplane's API server to users. Commandline terminals can be an unfriendly user interface for some, so users may have an interest in connecting their own frontend to their control plane. You are welcome to use any frontend that you like with Crossplane such as if you have built a home-grown web app, or you can integrate frontends like [Backstage](https://backstage.io/) or [Port](https://www.getport.io/).
+Most users don't want to directly expose their Crossplane's API server to users. Command line terminals can be an unfriendly interfaces for some, so users may want to connect their own frontend to their control plane. You can integrate any frontend with Crossplane, such as a home-grown web app, [Backstage](https://backstage.io/) or [Port](https://www.getport.io/).
 
 ## Integrating a platform frontend
 
-One of the most common use cases we see users building with Crossplane is an internal developer platform (IDP). A typical IDP has a GUI-based frontend which often provides UI-based form experiences that allows developers to self-service infrastructure and resources.
+One of the most common use cases Crossplane users have is to build an internal developer platform (IDP). A typical IDP has a GUI-based frontend which often provides UI-based form experiences that allows developers to self-service infrastructure and resources.
 
-The job of integrating a platform frontend with your control plane is therefore usually about translating a set of inputs collected from a form and sending that to a control plane. As mentioned above, you could configure your platform frontend to communicate directly with the API server of your control plane. However, we believe the better practice is to instead use your platform frontend to:
+Integrating a platform frontend with your control plane requires translating a set of inputs collected from a form and sending that to a control plane. You _could_ configure your platform frontend to communicate directly with the API server of your control plane. It's a better practice to instead use your platform frontend to:
 
 1. Collect the inputs you need to build a claim against your API
-2. Create the claim .YAML and submit that to the git repo syncing to your control plane
-3. A CD engine will apply the claim to your control plane and your control plane will react to the claim.
+2. Create the claim .YAML and submit that to the Git repository syncing to your control plane
+3. A CD engine applies the claim to your control plane and your control plane responds to the claim.
 
 ## Diagram
 
 {{<img src="xp-arch-framework/images/platform-frontend-flow.png" alt="A diagram demonstrating how a platform frontend generically integrates with Crossplane" size="medium" quality="100" align="center">}}
 
-In this flow, your platform doesn't communicate directly with your control plane; instead, it all operates via git, aligned to the recommendations we suggested in the [consuming your control plane API]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md#consume-control-plane-apis" >}}) section of the architectural guidance.
+Your platform doesn't communicate directly with your control plane. Instead, it all operates through Git, aligned to the recommendations found in [consuming your control plane API]({{< ref "xp-arch-framework/architecture/architecture-baseline-single.md#consume-control-plane-apis" >}}) section of the architectural guidance.

--- a/content/xp-arch-framework/interface-integrations/policy-engines.md
+++ b/content/xp-arch-framework/interface-integrations/policy-engines.md
@@ -8,16 +8,16 @@ description: "A guide for how to integrate control planes with a variety of inte
 This section is under construction - stay tuned for additional guidance and best practices for integrating policy engines with Crossplane.
 {{< /hint >}}
 
-An effective way to manage Crossplane is to enforce governance through policies. Any Kubernetes-compatible policy engine--such as [Open Policy Agent Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/) or [Kyverno](https://github.com/kyverno/kyverno)--can be installed alongside Crossplane. This allows users to write custom policies to enforce against Crossplane resources.
+An effective way to manage Crossplane is to enforce governance through policies. Any Kubernetes-compatible policy engine--such as [Open Policy Agent Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/) or [Kyverno](https://github.com/kyverno/kyverno)--is installable alongside Crossplane. This allows users to write custom policies to enforce against Crossplane resources.
 
 ## Kyverno
 
-Kyverno's Kubernetes-native policy engine is completely compatible with Crossplane. It works by running an admission controller on the cluster, after which you can author policies as Kubernetes resources.
+Kyverno's Kubernetes-native policy engine is compatible with Crossplane. It works by running an admission controller on the cluster, after which you can author policies as Kubernetes resources.
 
-## OPA Gatekeeper
+## Open Policy Agent Gatekeeper
 
 Open Policy Agent (OPA) Gatekeeper is another policy engine you can use with Crossplane. You author policies using [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/). 
 
 ## Applying policies to a control plane
 
-Don’t apply custom policies directly to the control plane. These policies are part of your control plane’s total configuration and should instead be defined in your control plane’s git repo source of truth (recommended earlier) and administered to your control plane that way. 
+Don't apply custom policies directly to the control plane. Policies are part of the total control plane configuration and their definition should live in the Git repository source of truth for your control plane. You can deploy them to your control plane using a CD engine.

--- a/content/xp-arch-framework/interface-integrations/secrets-management.md
+++ b/content/xp-arch-framework/interface-integrations/secrets-management.md
@@ -4,19 +4,19 @@ weight: 3
 description: "A guide for how to integrate control planes with a variety of interfaces"
 ---
 
-Kubernetes [secrets](https://kubernetes.io/docs/concepts/configuration/secret/) are objects that contain some sensitive data. In the case of Crossplane, that could be:
+Kubernetes [secrets](https://kubernetes.io/docs/concepts/configuration/secret/) are objects that contain some sensitive data. For Crossplane, that could be:
 
 * credentials for a provider
 * connection details to a resource
-* inputs that need to be passed to managed resources at creation time
+* inputs to managed resources at creation time
 
-Our baseline recommendation is to just use Kubernetes secrets. If you have business requirements that preclude this because you need to integrate Crossplane with a centralized secret management solution, we will document below how to do that.
+The baseline recommendation is to just use Kubernetes secrets. If you have business requirements to integrate Crossplane with a centralized secret management solution, the framework also documents below how to do that.
 
 ### Reading secrets
 
-To read secrets from an external source into your Crossplane cluster, we recommend installing the [External Secrets Operator](https://external-secrets.io) into your cluster. The External Secrets Operator is an open-source tool that implements a custom resource called `ExternalSecret` that defines where secrets live. 
+To read secrets from an external source into your Crossplane cluster, it's recommended to install the [External Secrets Operator](https://external-secrets.io) into your cluster. The External Secrets Operator is an open source tool that implements a custom resource called `ExternalSecret` that defines where secrets live. 
 
-To use the external secrets operator, you need to register a SecretStore. This could Vault, AWS Key Secrets Manager, or other central keystore services.
+To use the external secrets operator, you need to register a SecretStore. This could be AWS Key Secrets Manager, Vault, or other central secret management services.
 
 ```yaml
 apiVersion: external-secrets.io/v1beta1
@@ -39,7 +39,7 @@ spec:
           key: vault-token
 ```
 
-Once you have a secret store configured, you can pull external secrets into your control plane by creating new `ExternalSecrets`. As an example, this allows you to store ProviderConfig credentials in a central keystore and pull them into different control planes.
+Once you have a secret store configured, you can pull external secrets into your control plane by creating new `ExternalSecrets`. As an example, this allows you to store ProviderConfig credentials in a central secret management service and pull them into different control planes.
 
 ```yaml
 apiVersion: external-secrets.io/v1beta1
@@ -63,11 +63,11 @@ spec:
 
 ### Writing secrets
 
-When Crossplane creates a secret, the default mode is to write that the secret as a Kubernetes secret in its cluster. One common example of this is when you create a resource that generates connection details, this will get written to a local Kubernetes secret in the cluster. 
+When Crossplane creates a secret, the default mode is to write the secret as a Kubernetes secret in its cluster. One common example of this is when you create a resource that generates connection details. The connection details get written to a local Kubernetes secret in the cluster.
 
-If you need to write secrets to a centralized secret management solution outside of the cluster, you can rely on the fact that a secret is "just another Crossplane resource" in this case. You should create secrets in your desired secret store by composing the set of managed resources which represent the secret, and pull data from the Kubernetes secret that Crossplane creates.
+If you need to write secrets to a centralized secret management solution outside of the cluster, remember that a secret is "just another Crossplane resource." Create secrets in the desired secret store by composing the set of managed resources which generate the secret. Then, pull data from the Kubernetes secret that Crossplane creates.
 
-In the example below, we demonstrate a sample composition that stores the connection details for a GCP CloudSQL database into a secret in GCP Secret Manager.
+The example below demonstrates a composition that stores the connection details for a GCP CloudSQL database into a secret in GCP Secret Manager.
 
 ```yaml
 apiVersion: apiextensions.crossplane.io/v1
@@ -140,6 +140,6 @@ spec:
               matchControllerRef: true
 ```
 
-When a new composite resource gets created which uses this composition, a `kind: DatabaseInstance` managed resource gets created. it stores its connection details in a local secret in the cluster. A `kind: Secret` resource will get created, respresenting a new secret in GCP Secret Manager. Then a `kind: SecretVersion` resource gets created, which will transpose the data from a local Kubernetes secret to the secret contained in GCP.
+When a new composite resource gets created which uses this composition, a `kind: DatabaseInstance` managed resource gets created. it stores its connection details in a local secret in the cluster. A `kind: Secret` resource gets created, representing a new secret in GCP Secret Manager. Then a `kind: SecretVersion` resource gets created, which transposes the data from a local Kubernetes secret to the secret contained in GCP.
 
 This example is for GCP, but you would follow a similar pattern for other popular secret stores (AWS, Azure, Vault, etc), too.

--- a/utils/vale/styles/Google/Headings.yml
+++ b/utils/vale/styles/Google/Headings.yml
@@ -31,6 +31,8 @@ exceptions:
   - gRPC
   - Hugo
   - I
+  - Integrate Crossplane with Argo
+  - Integrate Crossplane with Flux
   - JavaScript
   - Kubeconfig
   - Kubernetes
@@ -38,6 +40,7 @@ exceptions:
   - macOS
   - Marketplace
   - MongoDB
+  - Open Policy Agent Gatekeeper
   - Provider
   - ProviderConfig
   - ProviderConfigs
@@ -47,6 +50,7 @@ exceptions:
   - TypeScript
   - Upbound
   - URLs
+  - Use patchSets
   - UXP
   - Vale
   - Vault

--- a/utils/vale/styles/Google/Headings.yml
+++ b/utils/vale/styles/Google/Headings.yml
@@ -7,9 +7,12 @@ match: $sentence
 indicators:
   - ':'
 exceptions:
+  - "Amazon Elastic Kubernetes Service"
   - "Composite Resource"
+  - "Google Kubernetes Engine"
   - "Managed Control Planes?"
   - "Managed Resources"
+  - "Microsoft Azure Kubernetes Service"
   - "OpenID Connect"
   - "Service Account"
   - "Universal Crossplane"
@@ -20,6 +23,7 @@ exceptions:
   - CLI
   - Code
   - Configuration
+  - Configuration layout in Git
   - ControllerConfigs
   - Cosmos
   - Crossplane

--- a/utils/vale/styles/Google/Headings.yml
+++ b/utils/vale/styles/Google/Headings.yml
@@ -16,6 +16,7 @@ exceptions:
   - "OpenID Connect"
   - "Service Account"
   - "Universal Crossplane"
+  - "Use OpenAPI v3 data types"
   - "Upbound Console"
   - "Upbound Universal Crossplane"
   - APIs?

--- a/utils/vale/styles/Microsoft/HeadingAcronyms.yml
+++ b/utils/vale/styles/Microsoft/HeadingAcronyms.yml
@@ -11,6 +11,7 @@ exceptions:
   - AWS
   - CLI
   - CSS
+  - CPU
   - EKS
   - GCP
   - IAM
@@ -18,3 +19,4 @@ exceptions:
   - OIDC
   - SCSS
   - UXP
+  - XRD

--- a/utils/vale/styles/Microsoft/Terms.yml
+++ b/utils/vale/styles/Microsoft/Terms.yml
@@ -5,7 +5,6 @@ ignorecase: true
 action:
   name: replace
 swap:
-  '(?:agent|virtual assistant|intelligent personal assistant)': personal digital assistant
   '(?:drive C:|drive C>|C: drive)': drive C
   '(?:internet bot|web robot)s?': bot(s)
   '(?:microsoft cloud|the cloud)': cloud

--- a/utils/vale/styles/Upbound/spelling-exceptions.txt
+++ b/utils/vale/styles/Upbound/spelling-exceptions.txt
@@ -3,6 +3,7 @@ Argo
 Autoscaling
 backports
 Bootstrap
+CLI's
 Commonmark
 conformant
 CRDs
@@ -12,12 +13,14 @@ Datadog
 declaratively
 downscaling
 editCode
+enums
 Env
 GCP's
 Geekdocs
 Goldmark
 Grammarly
 Grafana
+image_uri
 kubeconfig
 kubectl
 Kustomize

--- a/utils/vale/styles/Upbound/spelling-exceptions.txt
+++ b/utils/vale/styles/Upbound/spelling-exceptions.txt
@@ -1,4 +1,5 @@
 APIs
+Argo
 Autoscaling
 backports
 Bootstrap
@@ -7,6 +8,8 @@ conformant
 CRDs
 Crossplane
 Crossplane's
+Datadog
+declaratively
 downscaling
 editCode
 Env
@@ -14,8 +17,12 @@ GCP's
 Geekdocs
 Goldmark
 Grammarly
+Grafana
 kubeconfig
 kubectl
+Kustomize
+Kyverno
+Kyverno's
 MCP
 MCPs
 minikube
@@ -23,8 +30,10 @@ namespace
 namespaces
 Netlify
 OAuth
+patchSets
 proidc
 proselint
+Rego
 semver
 Serverless
 shortcode
@@ -37,6 +46,7 @@ Upbound
 Upbound's
 UXP
 uxp
+Velero
 VSCode
 Webpack
 xpkg

--- a/utils/vale/styles/gitlab/CurlStringsQuoted.yml
+++ b/utils/vale/styles/gitlab/CurlStringsQuoted.yml
@@ -8,6 +8,6 @@ extends: existence
 message: 'For consistency across all cURL examples, always wrap the URL in double quotes ("): %s'
 link: https://docs.gitlab.com/ee/development/documentation/restful_api_styleguide.html#curl-commands
 level: error
-scope: code
+scope: raw
 raw:
   - 'curl [^"]+://.*'

--- a/utils/vale/styles/gitlab/MeaningfulLinkWords.yml
+++ b/utils/vale/styles/gitlab/MeaningfulLinkWords.yml
@@ -7,7 +7,7 @@
 extends: existence
 message: 'Improve SEO and accessibility by rewriting "%s" in the link text.'
 level: warning
-scope: link
+scope: raw
 ignorecase: true
 link: https://about.gitlab.com/handbook/communication/#writing-style-guidelines
 tokens:

--- a/utils/vale/styles/gitlab/Uppercase.yml
+++ b/utils/vale/styles/gitlab/Uppercase.yml
@@ -126,6 +126,7 @@ exceptions:
   - OCI
   - OIDC
   - ONLY
+  - OPA
   - OSS
   - OTP
   - OWASP
@@ -224,3 +225,4 @@ exceptions:
   - YAML
   - ZAP
   - ZIP
+  - IDP


### PR DESCRIPTION
We merged the xp-arch-framework content without fixing the vale warnings around spelling and voicing. I've fixed all of them in this PR.