### PR TITLE
Fix CSS Caching

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,8 @@
-const postcssLightningcss = require("postcss-lightningcss");
+const postcssLightningcss = require("postcss-lightningcss")({
+  browsers: ">= .25%",
+  lightningcssOptions: {
+  }
+});
 
 const purgecss = require('@fullhuman/postcss-purgecss')({
   content: ['./hugo_stats.json'],
@@ -11,7 +15,7 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
       ...(els.ids || []),
     ];
   },
-  safelist: ['offcanvas-backdrop']
+  safelist: []
 });
 
 const mediasort = require('postcss-sort-media-queries')({

--- a/themes/upbound/layouts/partials/head/base.html
+++ b/themes/upbound/layouts/partials/head/base.html
@@ -10,7 +10,7 @@
 <link rel="canonical" href="https://docs.upbound.io{{ .Permalink }}">
 
 {{ partialCached "head/js/color-mode-js" . }}
-{{ partialCached "head/stylesheets/stylesheet" . }}
+{{ partial "head/stylesheets/stylesheet" . }}
 {{ partialCached "head/favicons" . }}
 
 {{/*  {{ partial "social" . }}  */}}


### PR DESCRIPTION
While testing some fixes for the img shortcode I noticed that we cache the production optimized stylesheet. Since the stylesheet is dynamically generated it can cause the cache reference to be wrong.

This PR removes caching of the stylesheet in hugo and adds an improvement for CSS optimization with PostCSS

Signed-off-by: Pete Lumbis <pete@upbound.io>	