### PR TITLE
Fix img shortcode

### DIFF
--- a/content/contribute/features.md
+++ b/content/contribute/features.md
@@ -144,18 +144,17 @@ The shortcode supports the following options:
 * `size` - Optional. Resizes the image. Useful for large images that need downscaling.
 * `quality` - Optional. A value between 1 and 100. Change the image quality to
   increase image quality or decrease image file size. The default is `quality=75`.
-* `lightbox` - Optional. Set to `true` to enable an image pop-out at full image
-  size. Useful for high fidelity screenshots.
+* `lightbox` - Optional. Set to `false` to disable the full-sized image pop.
 
 
 ### Resize images
 
 The `size` can be one of:
 * `xtiny` - Resizes the image to 150px.
-* `tiny` - Resizes the image to 320px.
+* `tiny` - Resizes the image to 300px.
 * `small` - Resizes the image to 600px.
-* `medium` - Resizes the image to 1200px.
-* `large` - Resizes the image to 1800px.
+* `medium` - Resizes the image to 800px.
+* `large` - Resizes the image to 1200px.
 
 By default the image isn't resized.
 
@@ -179,21 +178,6 @@ For example,
 
 Generates this image
 {{< img src="/concepts/images/WithUpbound.png" alt="Control planes with Upbound" size="xtiny" >}}
-
-### Image pop-outs
-
-Use the `lightbox=true` option to create a pop-out of an image that's full
-sized.
-
-<!-- vale gitlab.SubstitutionWarning = NO -->
-<!-- it's not a selection, they are clicking on image -->
-For example, render an `xtiny` image and click to see the full size.
-```html
-{{</* img src="/concepts/images/WithUpbound.png" size="xtiny" lightbox="true" alt="Control planes with Upbound"  */>}}
-```
-<!-- vale gitlab.SubstitutionWarning = YES -->
-
-{{< img src="/concepts/images/WithUpbound.png" size="xtiny" lightbox="true" alt="Control planes with Upbound"  >}}
 
 ## Tables
 The docs support 

--- a/content/contribute/features.md
+++ b/content/contribute/features.md
@@ -144,7 +144,7 @@ The shortcode supports the following options:
 * `size` - Optional. Resizes the image. Useful for large images that need downscaling.
 * `quality` - Optional. A value between 1 and 100. Change the image quality to
   increase image quality or decrease image file size. The default is `quality=75`.
-* `lightbox` - Optional. Set to `false` to disable the full-sized image pop.
+* `lightbox` - Optional. Set to `false` to turn off the full-sized image pop.
 
 
 ### Resize images

--- a/content/quickstart/aws-deploy.md
+++ b/content/quickstart/aws-deploy.md
@@ -27,11 +27,11 @@ Your first time in Upbound you must create an organization. Give your organizati
 
 Select **Create Organization**.
 
-{{<img src="quickstart/images/my-org.png" alt="Upbound Create organization screen" size="medium" quality="100" align="center">}}
+{{<img src="quickstart/images/my-org.png" alt="Upbound Create organization screen" size="original" quality="100" align="center" >}}
 
 On the next screen, start your free trial. This trial allows you to create up to three managed control planes, three configurations, and invite a total of 10 team members in an organization.
 
-{{<img src="quickstart/images/free-trial.png" alt="Upbound Free trial entry" size="medium" quality="100" align="center" >}}
+{{<img src="quickstart/images/free-trial.png" alt="Upbound Free trial entry" size="original" quality="100" align="center" >}}
 
 ### Choose a configuration
 
@@ -39,7 +39,7 @@ Upbound offers a curated gallery of Crossplane configurations for you to choose 
 
 Select the Configuration called **EKS as a service**. 
 
-{{<img src="quickstart/images/get-started-select-eks.png" alt="Choose an Upbound configuration" quality="100">}}
+{{<img src="quickstart/images/get-started-select-eks.png" alt="Choose an Upbound configuration" quality="100" size="medium" lightbox="true" >}}
 
 ### Connect to GitHub
 
@@ -47,7 +47,7 @@ After you've selected a Configuration, you need to connect Upbound to your GitHu
 
 Select **Connect to GitHub**.
 
-{{<img src="quickstart/images/get-started-select-gh.png" alt="a marketplace search filter with Providers and Official filters set" quality="100" lightbox="true">}}
+{{<img src="quickstart/images/get-started-select-gh.png" alt="a marketplace search filter with Providers and Official filters set" quality="100" size="medium" lightbox="true">}}
 
 {{< hint "tip" >}}
 Git connectivity is at the core of Upbound's workflows. To learn more about git integration, read the [GitOps with MCP]({{<ref "/concepts/control-plane-connector" >}}) section.
@@ -76,8 +76,7 @@ Give your control plane a name, like **my-control-plane**.
 
 Select **Create Control Plane**.
 
-{{<img src="quickstart/images/get-started-name-ctp.png" alt="Upbound Create Control Plane screen" quality="100" lightbox="true">}}
-
+{{<img src="quickstart/images/get-started-name-ctp.png" alt="Upbound Create Control Plane screen" quality="100" lightbox="true" size="medium" >}}
 
 
 ### Connect to AWS with OIDC
@@ -139,7 +138,7 @@ Return to Upbound and paste the ARN you copied in the previous step into the inp
 Select **Authenticate**.  
 Select **Confirm and Launch Control Plane**.
 
-{{<img src="quickstart/images/get-started-confirm-launch.png" alt="Upbound Get Started Confirm and Launch screen" quality="100" lightbox="true">}}
+{{<img src="quickstart/images/get-started-confirm-launch.png" alt="Upbound Get Started Confirm and Launch screen" quality="100" lightbox="true" size="medium">}}
 
 ## Welcome to the Upbound Console
 
@@ -186,7 +185,7 @@ After creating an instance, the _Events_ section are logs directly from Kubernet
 
 Crossplane commonly generates a Kubernetes error `cannot apply composite resource: cannot patch object: Operation cannot be fulfilled` that may appear as an _Event_.
 
-{{<img src="quickstart/images/event-error-cannot-patch.png" alt="Events showing the error cannot apply composite resource: cannot patch object" quality="100" align="center">}}
+{{<img src="quickstart/images/event-error-cannot-patch.png" alt="Events showing the error cannot apply composite resource: cannot patch object" quality="100" size="small" align="center">}}
 
 You can ignore this error. For more information about what causes this, read [Crossplane issue #2114](https://github.com/crossplane/crossplane/issues/2114).
 {{< /hint >}}

--- a/content/quickstart/azure-deploy.md
+++ b/content/quickstart/azure-deploy.md
@@ -30,11 +30,11 @@ Your first time in Upbound you must create an organization. Give your organizati
 
 Select **Create Organization**.
 
-{{<img src="quickstart/images/my-org.png" alt="Upbound Create organization screen" size="medium" quality="100" align="center">}}
+{{<img src="quickstart/images/my-org.png" alt="Upbound Create organization screen" size="medium" quality="100" align="center" size="original" >}}
 
 On the next screen, start your free trial. This trial allows you to create up to three managed control planes, three configurations, and invite a total of 10 team members in an organization.
 
-{{<img src="quickstart/images/free-trial.png" alt="Upbound Free trial entry" size="medium" quality="100" align="center" >}}
+{{<img src="quickstart/images/free-trial.png" alt="Upbound Free trial entry" size="original" quality="100" align="center" >}}
 
 ### Choose a configuration
 
@@ -42,7 +42,7 @@ Upbound offers a curated gallery of Crossplane configurations for you to choose 
 
 Select the Configuration called **AKS as a service**. 
 
-{{<img src="quickstart/images/azure-config.png" alt="Upbound Azure configuration" quality="100">}}
+{{<img src="quickstart/images/azure-config.png" alt="Upbound Azure configuration" size="medium" quality="100">}}
 ### Connect to GitHub
 
 After you've selected a Configuration, you need to connect Upbound to your GitHub account. Upbound uses GitHub's authorization flow and installs a GitHub app into your account. 
@@ -75,7 +75,7 @@ Give your control plane a name, like **my-control-plane**.
 
 Select **Create Control Plane**.
 
-{{<img src="quickstart/images/get-started-name-ctp.png" alt="Upbound Create Control Plane screen" quality="100" align="center">}}
+{{<img src="quickstart/images/get-started-name-ctp.png" alt="Upbound Create Control Plane screen" quality="100" align="center" size="medium">}}
 
 ### Connect to Azure with OIDC
 
@@ -92,7 +92,7 @@ Upbound recommends using OpenID Connect (OIDC) to authenticate to Azure without 
 6. In the _Supported account types_ section select **Accounts in this organizational directory only**.
 7. In the _Redirect URI_ section select **Web** and leave the URL field blank.
 8. Select **Register**.
-{{<img src="quickstart/images/azure-identity-start.png" alt="Upbound Get Started Configure OIDC screen for Azure" quality="100" align="center" >}}
+{{<img src="quickstart/images/azure-identity-start.png" alt="Upbound Get Started Configure OIDC screen for Azure" quality="100" align="center" size="medium" >}}
 
 #### Create a federated credential 
 
@@ -130,7 +130,7 @@ upbound MCP $@<your-org>/<your-control-plane-name>$@ Provider provider-azure
 9. Leave _Audience_ unmodified with **api://AzureADTokenExchange**.
 10. Select **Add**.
 
-{{<img src="quickstart/images/azure-registration-config.png" alt="Azure configure app registration" quality="100" align="center" >}}
+{{<img src="quickstart/images/azure-registration-config.png" alt="Azure configure app registration" quality="100" align="center" size="medium">}}
 
 #### Grant permissions to the service principal
 
@@ -150,7 +150,7 @@ For your control plane to be able to perform actions required by this configurat
 12. Select **Review + assign**.
 13. Make sure everything is correct and press **Review + assign** again.
 
-{{<img src="quickstart/images/azure-identity-setup.png" alt="Azure grant permissions to service principal" quality="100" align="center" >}}
+{{<img src="quickstart/images/azure-identity-setup.png" alt="Azure grant permissions to service principal" quality="100" align="center" size="medium" >}}
 
 ### Finish configuring the Upbound identity provider
 
@@ -171,7 +171,7 @@ Select **Launch Control Plane**.
 
 After completing the _Get Started_ experience, you are in the Upbound Console and greeted by the Control Planes screen.
 
-{{<img src="quickstart/images/control-plane-console.png" alt="Upbound Azure control plane instance screen" quality="100" align="center">}}
+{{<img src="quickstart/images/control-plane-console.png" alt="Upbound Azure control plane instance screen" quality="100" align="center" size="medium">}}
 
 The control plane details view gives users a view into what's happening on their control planes. 
 
@@ -183,12 +183,12 @@ Read about the [Upbound Console]({{<ref "concepts/console">}}) for a full tour o
 
 From the control planes view, select the **Portal** tab, and select **Open Control Plane Portal**.
 
-{{<img src="quickstart/images/get-started-portal-link.png" alt="Navigate to control plane portal" quality="100" lightbox="true">}}
+{{<img src="quickstart/images/get-started-portal-link.png" alt="Navigate to control plane portal" quality="100" lightbox="true" size="medium">}}
 
 The Control Plane Portal lists the available resources that users can claim in the left-side menu.  
 These resources are your abstracted APIs presented to users. 
 
-{{<img src="quickstart/images/cp-create-kubernetescluster.png" alt="Control plane portal with a Kubernetes Cluster resource" quality="100" align="center">}}
+{{<img src="quickstart/images/cp-create-kubernetescluster.png" alt="Control plane portal with a Kubernetes Cluster resource" quality="100" align="center" size="medium">}}
 
 Select the **KubernetesCluster** resource and then select the **Create New** button at the top of the page. 
 
@@ -203,7 +203,7 @@ The form are the parameters defined in your custom API. Fill-in the form with th
 - _size_: **small**
 <!-- vale Google.FirstPerson = YES -->
 
-{{<img src="quickstart/images/get-started-k8s-cluster-create.png" alt="Navigate to control plane portal" quality="100" lightbox="true">}}
+{{<img src="quickstart/images/get-started-k8s-cluster-create.png" alt="Navigate to control plane portal" quality="100" lightbox="true" size="medium">}}
 
 When you **Create Instance** the portal generates a Crossplane claim.
 
@@ -212,7 +212,7 @@ After creating an instance, the _Events_ section are logs directly from Kubernet
 
 Crossplane commonly generates a Kubernetes error `cannot apply composite resource: cannot patch object: Operation cannot be fulfilled` that may appear as an _Event_.
 
-{{<img src="quickstart/images/event-error-cannot-patch.png" alt="Events showing the error cannot apply composite resource: cannot patch object" quality="100" align="center">}}
+{{<img src="quickstart/images/event-error-cannot-patch.png" alt="Events showing the error cannot apply composite resource: cannot patch object" quality="100" align="center" size="medium">}}
 
 You can ignore this error. For more information about what causes this, read [Crossplane issue #2114](https://github.com/crossplane/crossplane/issues/2114).
 {{< /hint >}}
@@ -225,7 +225,7 @@ There's now a claim card next to the `KubernetesCluster` type card.
 
 Select the claim and Upbound renders the full resource tree that's getting created and managed by your managed control plane. 
 
-{{<img src="quickstart/images/get-started-k8s-created.png" alt="Navigate to control plane portal" quality="100" lightbox="true">}}
+{{<img src="quickstart/images/get-started-k8s-created.png" alt="Navigate to control plane portal" quality="100" lightbox="true" size="medium">}}
 
 Congratulations, you created your first resources with your control plane.
 

--- a/content/quickstart/gcp-deploy.md
+++ b/content/quickstart/gcp-deploy.md
@@ -29,11 +29,11 @@ Your first time in Upbound you must create an organization. Give your organizati
 
 Select **Create Organization**.
 
-{{<img src="quickstart/images/my-org.png" alt="Upbound Create organization screen" size="medium" quality="100" align="center">}}
+{{<img src="quickstart/images/my-org.png" alt="Upbound Create organization screen" size="original" quality="100" align="center">}}
 
 On the next screen, start your free trial. This trial allows you to create up to three managed control planes, three configurations, and invite a total of 10 team members in an organization.
 
-{{<img src="quickstart/images/free-trial.png" alt="Upbound Free trial entry" size="medium" quality="100" align="center" >}}
+{{<img src="quickstart/images/free-trial.png" alt="Upbound Free trial entry" size="original" quality="100" align="center" >}}
 
 ### Choose a configuration
 
@@ -41,7 +41,7 @@ Upbound offers a curated gallery of Crossplane configurations for you to choose 
 
 Select the Configuration called **CloudSQL as a service**. 
 
-{{<img src="quickstart/images/cloudsql-config.png" alt="Upbound connect to GitHub screen" quality="100">}}
+{{<img src="quickstart/images/cloudsql-config.png" alt="Upbound connect to GitHub screen" size="medium" quality="100">}}
 ### Connect to GitHub
 
 After you've selected a Configuration, you need to connect Upbound to your GitHub account. Upbound uses GitHub's authorization flow and installs a GitHub app into your account. 
@@ -74,7 +74,7 @@ Give your control plane a name, like **my-control-plane**.
 
 Select **Create Control Plane**.
 
-{{<img src="quickstart/images/get-started-name-ctp.png" alt="Upbound Create Control Plane screen" quality="100" align="center">}}
+{{<img src="quickstart/images/get-started-name-ctp.png" alt="Upbound Create Control Plane screen" quality="100" align="center" size="medium" >}}
 
 ### Connect to GCP with OIDC
 
@@ -208,7 +208,7 @@ Go to the [Cloud SQL Admin API](https://console.cloud.google.com/apis/library/sq
 
 Select **Enable**.
 
-{{<img src="quickstart/images/enable-cloud-sql-api.png" alt="Enable the Cloud SQL Admin API in the GCP console" size="medium" quality="100" >}}
+{{<img src="quickstart/images/enable-cloud-sql-api.png" alt="Enable the Cloud SQL Admin API in the GCP console" size="original" quality="100" >}}
 <!-- vale Google.Headings = YES -->
 <!-- vale Microsoft.Terms = YES -->
 
@@ -247,7 +247,7 @@ Select **Launch Control Plane**.
 
 After completing the _Get Started_ experience, you are in the Upbound Console and greeted by the Control Planes screen.
 
-{{<img src="quickstart/images/gcp-ctp.png" alt="Upbound GCP instance screen" quality="100" align="center">}}
+{{<img src="quickstart/images/gcp-ctp.png" alt="Upbound GCP instance screen" quality="100" size="medium" align="center">}}
 
 The control plane details view gives users a view into what's happening on their control planes. 
 
@@ -259,7 +259,7 @@ Read about the [Upbound Console]({{<ref "concepts/console">}}) for a full tour o
 
 From the control planes view, select the **Portal** tab, and select **Open Control Plane Portal**.
 
-{{<img src="quickstart/images/get-started-portal-link.png" alt="Navigate to control plane portal" quality="100" lightbox="true">}}
+{{<img src="quickstart/images/get-started-portal-link.png" alt="Navigate to control plane portal" quality="100" lightbox="true" size="medium" >}}
 
 Select the **PostgreSQLInstance** resource.  
 Select the **Create New** button at the top-right of the page. 
@@ -276,7 +276,7 @@ The form are the parameters defined in your custom API. Fill-in the form with th
 <!-- vale Google.FirstPerson = YES -->
 
 
-{{<img src="quickstart/images/gcp-db-create.png" alt="Create database form" quality="100" lightbox="true">}}
+{{<img src="quickstart/images/gcp-db-create.png" alt="Create database form" quality="100" lightbox="true" size="medium">}}
 
 
 When you **Create Instance** the portal generates a Crossplane claim.
@@ -286,7 +286,7 @@ After creating an instance, the _Events_ section are logs directly from Kubernet
 
 Crossplane commonly generates a Kubernetes error `cannot apply composite resource: cannot patch object: Operation cannot be fulfilled` that may appear as an _Event_.
 
-{{<img src="quickstart/images/gcp-event-error-cannot-patch.png" alt="Events showing the error cannot apply composite resource: cannot patch object" quality="100" align="center">}}
+{{<img src="quickstart/images/gcp-event-error-cannot-patch.png" alt="Events showing the error cannot apply composite resource: cannot patch object" quality="100" align="center" size="medium">}}
 
 You can ignore this error. For more information about what causes this, read [Crossplane issue #2114](https://github.com/crossplane/crossplane/issues/2114).
 {{< /hint >}}
@@ -300,7 +300,7 @@ There's now a claim card next to the `PostgreSQLInstance` type card.
 
 Select the claim and Upbound renders the full resource tree that's getting created and managed by your managed control plane. 
 
-{{<img src="quickstart/images/gcp-observe-db.png" alt="Observe created resource" quality="100" lightbox="true">}}
+{{<img src="quickstart/images/gcp-observe-db.png" alt="Observe created resource" quality="100" lightbox="true" size="medium">}}
 
 Congratulations, you created your first resources with your MCP.
 

--- a/themes/upbound/layouts/shortcodes/img.html
+++ b/themes/upbound/layouts/shortcodes/img.html
@@ -24,12 +24,13 @@
   {{ $align = "d-flex" }}
 {{ end }}
 
-{{ $lightbox := false }}
-{{ if .Get "lightbox" }}
-  {{ if ne (.Get "lightbox") false }}
-    {{ $lightbox = true }}
+{{ $lightbox := true }}
+{{ with .Get "lightbox" }}
+  {{ if eq . "false" }}
+    {{ $lightbox = false }}
   {{ end }}
 {{ end }}
+
 
 {{ $quality := "q75" }}
 {{ if .Get "quality" }}
@@ -45,43 +46,27 @@
 {{ with $source }}
 
   {{/*  Render the images used by srcset  */}}
-  {{ $tiny := (.Resize (printf "320x webp  %s" $quality)) }}
+  {{ $xtiny := (.Resize (printf "150x webp  %s" $quality)) }}
+  {{ $tiny := (.Resize (printf "300x webp  %s" $quality)) }}
   {{ $small := (.Resize (printf "600x webp %s" $quality)) }}
-  {{ $medium := (.Resize (printf "1200x webp %s" $quality)) }}
+  {{ $medium := (.Resize (printf "800x webp %s" $quality)) }}
+  {{ $large := (.Resize (printf "1200x webp %s" $quality)) }}
   {{ $original := (.Resize (printf "%dx%d webp %s" .Width .Height $quality)) }}
-  {{ $xtiny := . }}
-  {{ $large := . }}
 
-  {{/*  Only resize these images if required  */}}
-  {{ if or $lightbox (eq $customSize "original") }}
-    {{ $original = (.Resize (printf "%dx%d webp %s" .Width .Height $quality)) }}
-  {{ end }}
-  {{ if eq $customSize "xtiny" }}
-    {{ $xtiny = (.Resize (printf "150x webp %s" $quality)) }}
-  {{ end }}
-  {{ if eq $customSize "large" }}
-    {{ $large = (.Resize (printf "1800x webp  %s" $quality)) }}
-  {{ end }}
 
   {{ $size := dict "xtiny" $xtiny "tiny" $tiny "small" $small "medium" $medium "large" $large "original" $original }}
   {{ $resizedImage := (index $size $customSize) }}
 
-<div class="{{ $align }}">
+  <div class="{{ $align }}">
 
-  {{ if $lightbox }}
-    <a href="{{$source.Permalink}}" data-lightbox="{{.}}" data-alt="{{$customAlt}}">
-  {{ end }}
-
+{{/* Spacing here is important. If there is space between the <a href>/</a> and <img> tags then it won't render properly in {{hint}} blocks */}}
+  {{ if $lightbox }}<a href="{{$source.Permalink}}" data-lightbox="{{.}}" data-alt="{{$customAlt}}">{{ end }}
   <img loading="{{$loading}}"
-  src="{{ $original.RelPermalink }}"
-  height="{{ $original.Height }}"
-  width="{{ $original.Width }}"
+  src="{{ $resizedImage.RelPermalink }}"
+  height="{{ $resizedImage.Height }}"
+  width="{{ $resizedImage.Width }}"
   class="rounded img-fluid mb-4"
   alt="{{ $customAlt }}"
-  decoding="async">
-
-  {{ if $lightbox }}
-    </a>
-  {{ end }}
+  decoding="async">{{ if $lightbox }}</a>{{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
`img` shortcode was effectively disabled at launch time. This turns the img shortcode back on and applies some image fixes to the quickstart. 

Visual inspection of other pages looked like quality was good and images didn't need adjusting. 


Signed-off-by: Pete Lumbis <pete@upbound.io>	