### PR TITLE
Temporarily disable left-nav scroll

### DIFF
--- a/themes/upbound/assets/scss/_left-sidebar-nav.scss
+++ b/themes/upbound/assets/scss/_left-sidebar-nav.scss
@@ -2,8 +2,8 @@
 
 // Custom modifications to built-in bootstrap tooling for the left-hand-nav/a
 #left-nav-menu {
-    overflow: scroll;
-    height: 100vh;
+    // overflow: scroll;
+    // height: 100vh;
     position: sticky;
     top: 40px;
 }


### PR DESCRIPTION
The left-nav scroll is causing UI issues on systems that have scrollbars displayed by default. Will disable this on Prod while working on a fix.