### PR TITLE
Update Right Nav Hover State & Fix Left Nav Pressed State

### DIFF
--- a/themes/upbound/assets/scss/_left-sidebar-nav.scss
+++ b/themes/upbound/assets/scss/_left-sidebar-nav.scss
@@ -25,4 +25,3 @@
         min-width: 28px;
     }
 }
-

--- a/themes/upbound/assets/scss/_right-sidebar-toc.scss
+++ b/themes/upbound/assets/scss/_right-sidebar-toc.scss
@@ -70,7 +70,7 @@
         }
 
         .nav-link:hover {
-            color: #{$font-color-dark} !important;   
+            text-decoration: underline;   
         }
     }
 }

--- a/themes/upbound/assets/scss/bootstrap/_list-group.scss
+++ b/themes/upbound/assets/scss/bootstrap/_list-group.scss
@@ -61,11 +61,6 @@
     text-decoration: none;
     background-color: var(--#{$prefix}list-group-action-hover-bg);
   }
-
-  &:active {
-    color: var(--#{$prefix}list-group-action-active-color);
-    background-color: var(--#{$prefix}list-group-action-active-bg);
-  }
 }
 
 // Individual list items
@@ -100,7 +95,7 @@
   &.active {
     z-index: 2; // Place active items above their siblings for proper border styling
     color: var(--#{$prefix}list-group-active-color);
-    background-color: var(--#{$prefix}list-group-active-bg);
+    background-color: var(--#{$prefix}list-group-active-bg) !important;
     border-color: var(--#{$prefix}list-group-active-border-color);
   }
 


### PR DESCRIPTION
- Use underline instead of color for right nav anchor link hover
- Remove purple pressed state for left nav pages that resulted in a gray>purple>gray>purple flicker