### PR TITLE
add an alias to redirect original CLI URL

### DIFF
--- a/content/reference/cli/_index.md
+++ b/content/reference/cli/_index.md
@@ -3,6 +3,8 @@ title: "Up CLI"
 icon: "terminal"
 weight: 1
 description: "Install Crossplane, interact with the Upbound Marketplace and Managed Control Planes with the Upbound Up CLI."
+aliases: 
+  - /cli
 ---
 
 The Upbound `up` command-line enables interaction with Upbound managed control planes. It also simplifies common workflows with Upbound Universal Crossplane (UXP) and building Crossplane packages for the Upbound Marketplace or any OCI-compliant registry.


### PR DESCRIPTION
add an alias to redirect original CLI url to avoid breaking google results
