### PR TITLE
Observability doc fixes

### DIFF
--- a/content/spaces/observability.md
+++ b/content/spaces/observability.md
@@ -83,62 +83,6 @@ Assuming your Prometheus helm release name is `prometheus`,
 the following configures monitoring:
 ```shell
 kubectl apply -f - <<EOM
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    # this is the default label used by the prometheus operator to determine which services
-    # to scrape. You may need to adjust labels depending on your installation.
-    release: prometheus
-  name: kube-state-metrics
-  namespace: monitoring
-spec:
-  endpoints:
-  - honorLabels: true
-    path: /metrics
-    port: http
-    scheme: http
-    scrapeTimeout: 10s
-  namespaceSelector:
-    any: true
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: kube-state-metrics
-      app.kubernetes.io/component: metrics
-      app.kubernetes.io/instance: kube-state-metrics
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    # this is the default label used by the prometheus operator to determine which services
-    # to scrape. You may need to adjust labels depending on your installation.
-    release: prometheus
-  name: mxp-gateway-metrics
-  namespace: monitoring
-spec:
-  endpoints:
-  - honorLabels: true
-    path: /metrics
-    port: metrics
-    scheme: http
-    scrapeTimeout: 10s
-  - relabelings:
-    - action: labeldrop
-      regex: pod
-    - action: labeldrop
-      regex: service
-    - action: labeldrop
-      regex: instance
-  namespaceSelector:
-    any: true
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: mxp-gateway
-      vcluster.loft.sh/managed-by: vcluster
-      vcluster.loft.sh/namespace: upbound-system
----
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/content/spaces/observability.md
+++ b/content/spaces/observability.md
@@ -49,17 +49,24 @@ Prometheus may not meet an Operators business or technology requirements.
 Upbound advises operators to consider what metrics and observability stack meet
 meet their needs before running in production.
 
-The recommended way to install Prometheus is through [the official helm charts](https://github.com/prometheus-community/helm-charts)
+The recommended way to install Prometheus is through
+[the official helm charts](https://github.com/prometheus-community/helm-charts).
 
+Add the Prometheus chart repo:
 ```shell
-# Add the prometheus helm char
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-# Install prometheus, kube-state-metrics and prometheus. See
-# the official docs the "offical helm charts" link above.
+```
+
+Install Prometheus, Alertmanager, Prometheus node exporter, kube-state-metrics,
+and Grafana:
+```shell
 helm install \
     -n monitoring --create-namespace \
     prometheus prometheus-community/kube-prometheus-stack
 ```
+
+See the [official
+docs](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#kube-prometheus-stack).
 
 ### Add monitors
 
@@ -75,7 +82,7 @@ For those wanting to just scrape OpenTelemetry metrics:
 Assuming your Prometheus helm release name is `prometheus`,
 the following configures monitoring:
 ```shell
-kubectl apply -f -<<EOM
+kubectl apply -f - <<EOM
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/content/spaces/observability.md
+++ b/content/spaces/observability.md
@@ -52,7 +52,7 @@ meet their needs before running in production.
 The recommended way to install Prometheus is through
 [the official helm charts](https://github.com/prometheus-community/helm-charts).
 
-Add the Prometheus chart repo:
+Add the Prometheus chart repository:
 ```shell
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 ```


### PR DESCRIPTION
This removes the servicemonitors for kube-state-metrics and mxp-gateway. The control-plane KSM doesn't have any metrics useful outside of billing, and mxp-gateway should be getting scraped by otlp-collector.

There are also some minor changes for readability.