### PR TITLE
add redirect for link in a blog post

### DIFF
--- a/content/providers/_index.md
+++ b/content/providers/_index.md
@@ -3,6 +3,8 @@ title: "Official Providers"
 weight: 350
 icon: "upbound-official"
 description: Upbound creates, maintains and supports a set of Crossplane providers called official providers.
+aliases:
+    - upbound-marketplace/providers
 ---
 Upbound creates, maintains and supports a set of Crossplane providers called **official providers**.  
 


### PR DESCRIPTION
User in slack noticed the link in [provider families blog](https://blog.upbound.io/new-provider-families) was broken.

This adds an alias to redirect to the correct page.