### PR TITLE
Repurpose OIDC docs to explain how to connect a managed control plane…

### DIFF
--- a/content/concepts/mcp/bring-your-own-controller.md
+++ b/content/concepts/mcp/bring-your-own-controller.md
@@ -1,5 +1,5 @@
 ---
-title: Orchestrate Internal Resources 
+title: Orchestrate internal resources 
 weight: 500
 description: Manage internal resources with managed control planes even if their APIs are not exposed to the internet.
 aliases:

--- a/content/concepts/mcp/control-plane-connector.md
+++ b/content/concepts/mcp/control-plane-connector.md
@@ -1,5 +1,5 @@
 ---
-title: GitOps with Control Planes
+title: GitOps with control planes
 weight: 6
 description: An introduction to doing GitOps with control planes on Upbound
 aliases: 

--- a/content/concepts/mcp/oidc.md
+++ b/content/concepts/mcp/oidc.md
@@ -1,58 +1,145 @@
 ---
-title: Provider Identity with OIDC
+title: Connect managed control planes to external services
 weight: 3
-description: Authenticating providers to external services using OpenID Connect.
+description: A guide for authenticating managed control plane with external services, including using OIDC
 ---
 
-Crossplane providers use a `ProviderConfig` Kubernetes object to
-supply credentials to authenticate with external services. For
-example, 
-[Upbound's AWS provider](https://marketplace.upbound.io/providers/upbound/provider-aws/latest)
-offers a
-[`ProviderConfig`](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/resources/aws.upbound.io/ProviderConfig/v1beta1)
-that supports 
-[supplying credentials](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/resources/aws.upbound.io/ProviderConfig/v1beta1#doc:spec-credentials-source)
-via a Kubernetes `Secret`, environment variable, file, and more. Users can
-create multiple `ProviderConfig` instances and reference them from the
-`spec.providerConfigRef` field of any managed resource.
+Managed control planes use [Crossplane providers](https://docs.crossplane.io/latest/concepts/providers/) to interact with external services. External services could be hyper scale cloud providers, version control services, ticketing platforms, or anything else that has a public API. Control planes can connect to an unlimited number of external services--just as long as there's an associated Crossplane provider in the [Upbound Marketplace](https://marketplace.upbound.io/providers).
 
-Providers in Upbound managed control planes can also use an `Upbound` credential 
-source called **Provider Identity**.  
+## How to connect to an external service
 
-The `Upbound` credential source uses OpenID Connect (`OIDC`) to 
-authenticate to providers without requiring users to store credentials on Upbound. 
+### Install a provider on your control plane
 
-This authentication method is comparable to
-["workload identity"](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) 
-offered by some managed Kubernetes providers.
+Install a Crossplane provider on your managed control plane by declaring a dependency on the desired provider package in your control plane's [configuration]({{<ref "concepts/control-plane-configurations.md" >}}) source. 
 
-## OpenID Connect
+### Configure the provider
 
-[OpenID Connect (OIDC)](https://openid.net/connect/) is a protocol that's built
-on top of [OAuth 2.0](https://oauth.net/2/). It serves to establish the identity
-of an entity in one environment that's attempting to access resources in another.
+Crossplane providers use a [`ProviderConfig`](https://docs.crossplane.io/latest/concepts/providers/#provider-configuration) Kubernetes object to supply credentials to authenticate with external services. For example, [Upbound's AWS provider](https://marketplace.upbound.io/providers/upbound/provider-aws/latest) offers a [`ProviderConfig`](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/resources/aws.upbound.io/ProviderConfig/v1beta1) that supports [supplying credentials](https://marketplace.upbound.io/providers/upbound/provider-aws/latest/resources/aws.upbound.io/ProviderConfig/v1beta1#doc:spec-credentials-source) via a Kubernetes `Secret`, environment variable, file, and more. 
 
-OIDC calls the two parties the **OpenID Providers (OPs)** and **Relying Parties (RPs)**. 
-Managed control planes define these roles as follows:
+### Connect to multiple accounts within a service
+
+You can create multiple `ProviderConfig` objects for a single provider in a managed control plane. You can create new ProviderConfigs on your control plane via the Upbound Console or by [connecting directly]({{<ref "concepts/mcp/#connect-directly-to-your-mcp">}}) to your control plane and creating new ProviderConfigs on it.
+
+For example, imagine you have `team-a` and `team-b` sharing a single managed control plane. Suppose each team should only be able to create resources in their respective cloud account in AWS. You would create two ProviderConfigs as demonstrated below:
+
+```yaml
+# This is the ProviderConfig that will get used by team-a
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: team-a-config
+spec:
+  credentials:
+    secretRef:
+      key: credentials
+      name: team-a-account-creds
+      namespace: upbound-system
+    source: Secret
+---
+# This is the ProviderConfig that will get used by team-b
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: team-b-config
+spec:
+  credentials:
+    secretRef:
+      key: credentials
+      name: team-b-account-creds
+      namespace: upbound-system
+    source: Secret
+```
+
+When a team creates resources with the control plane, reference the appropriate ProviderConfig to use from the `spec.providerConfigRef` field of any managed resource.
+
+{{<hint "tip" >}}
+The example above demonstrates ProviderConfigs using simple account credentials. **Don't use this auth method for production purposes.** Instead, configure your providers to use Upbound Identity, which is based on OIDC and described below.
+{{< /hint >}}
+
+## Use OpenID Connect with Upbound
+
+Providers in Upbound managed control planes can also use an `Upbound` credential source called **Provider Identity**. The `Upbound` credential source uses OpenID Connect (`OIDC`) to authenticate to providers without requiring users to store credentials on Upbound. This authentication method is comparable to ["workload identity"](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) offered by some managed Kubernetes services.
+
+[OpenID Connect (OIDC)](https://openid.net/connect/) is a protocol that's built on top of [OAuth 2.0](https://oauth.net/2/). It serves to establish the identity of an entity in one environment that's attempting to access resources in another.
+
+### Configure Upbound identity for a provider
+
+To configure a provider on a managed control plane to use Upbound Identity, use the auth method called `Upbound`. Exact configuration varies depending on the provider. Find examples below for AWS, Azure, and GCP:
+
+#### Upbound identity for AWS example
+
+First, [add Upbound]({{<ref "quickstart/aws-deploy.md#add-upbound-as-an-openid-connect-provider" >}}) as an OpenID Connect provider in your AWS account. Then, create a ProviderConfig on your control plane with the following configuration:
+
+{{< editCode >}}
+```yaml
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Upbound
+    upbound:
+      webIdentity:
+        roleARN: $@<arn:aws:iam::12345969492:role/your-role>$@ 
+```
+{{< /editCode >}}
+
+#### Upbound identity for Azure example
+
+First, [register Upbound]({{<ref "quickstart/azure-deploy.md#connect-to-azure-with-oidc" >}}) with Azure Active Directory in your Azure account. Then, create a ProviderConfig on your control plane with the following configuration:
+
+{{< editCode >}}
+```yaml
+apiVersion: azure.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  clientID: $@<client-id>$@ 
+  tenantID: $@<tenant-id>$@ 
+  subscriptionID: $@<subscription-id>$@ 
+  credentials:
+    source: Upbound
+```
+{{< /editCode >}}
+
+#### Upbound identity for GCP example
+
+First, [configure Upbound]({{<ref "quickstart/gcp-deploy.md#connect-to-gcp-with-oidc" >}}) for workload identity federation in your GCP account. Then, create a ProviderConfig on your control plane with the following configuration:
+
+{{< editCode >}}
+```yaml
+apiVersion: gcp.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  projectID: $@<your-gcp-project>$@
+  credentials:
+    source: Upbound
+    upbound:
+      federation:
+        providerID: $@projects/<project-id>/locations/global/workloadIdentityPools/<identity-pool>/providers/<identity-provider>$@ 
+        serviceAccount: $@<service-account-name>@<project-name>.iam.gserviceaccount.com>$@ 
+```
+{{< /editCode >}}
+
+### OIDC explained
+
+OIDC calls the two parties the **OpenID Providers (OPs)** and **Relying Parties (RPs)**. Managed control planes define these roles as follows:
 
 - **OpenID Provider**: Upbound
 - **Relying Party**: an external service that supports OIDC, for example, AWS, Azure or GCP
  
-Users set up a _trust relationship_ between Upbound and the external
-service. Upbound uses the trust relationship instead of storing credentials for an 
-external service in the managed control plane. 
+Users set up a _trust relationship_ between Upbound and the external service. Upbound uses the trust relationship instead of storing credentials for an external service in the managed control plane. 
 
 
-Upbound injects an _identity token_ into the file system of every
-provider `Pod`. Upbound sends the token to the external service and exchanges it for a
-short-lived credential. Upbound uses the short-lived credential to perform 
-operations against the external service.
+Upbound injects an _identity token_ into the file system of every provider `Pod`. Upbound sends the token to the external service and exchanges it for a short-lived credential. Upbound uses the short-lived credential to perform operations against the external service.
 
-## Creating trust relationships
+#### Creating trust relationships
 
-Every OIDC relying party implements its own mechanism for establishing a trust
-relationship and associating permissions. Typically, the process involves
-the following broad steps:
+Every OIDC relying party implements its own mechanism for establishing a trust relationship and associating permissions. Typically, the process involves the following broad steps:
 
 1. Specifying the _issuer_. For Upbound, this is `https://proidc.upbound.io`.
 2. Specifying an _audience_. This may vary by relying party.
@@ -60,20 +147,13 @@ the following broad steps:
    token can assume.
 4. Associating permissions with the role or service account.
 
-Different OIDC relaying parties may define valid tokens differently. Typically 
-it involves writing a policy that restricts what _subject_ can assume 
-the role or service account.
+Different OIDC relaying parties may define valid tokens differently. Typically it involves writing a policy that restricts what _subject_ can assume the role or service account.
 
 {{<hint "warning" >}} 
-Authoring a policy with appropriate access controls
-is critical to ensure that only your provider in your managed control plane is
-able to assume the role or service account. 
+Authoring a policy with appropriate access controls is critical to ensure that only your provider in your managed control plane is able to assume the role or service account. 
 {{< /hint >}}
 
-Identity tokens are
-[JSON Web Tokens (`JWTs`)](https://www.rfc-editor.org/rfc/rfc7519). 
-The OIDC _claims_ supported by Upbound are available in the OIDC metadata
-endpoint at `https://proidc.upbound.io/.well-known/openid-configuration`.
+Identity tokens are [JSON Web Tokens (`JWTs`)](https://www.rfc-editor.org/rfc/rfc7519). The OIDC _claims_ supported by Upbound are available in the OIDC metadata endpoint at `https://proidc.upbound.io/.well-known/openid-configuration`.
 
 ```json
 {
@@ -100,31 +180,21 @@ endpoint at `https://proidc.upbound.io/.well-known/openid-configuration`.
 }
 ```
 
-OIDC relying parties use this information to validate identity tokens. 
-Relying parties use the `jwks_uri` to ensure that the OIDC provider signed the 
-identity token with their private key. The private key must
-correspond to one of the public keys from
-`https://proidc.upbound.io/.well-known/jwks`. 
+OIDC relying parties use this information to validate identity tokens. Relying parties use the `jwks_uri` to ensure that the OIDC provider signed the identity token with their private key. The private key must correspond to one of the public keys from `https://proidc.upbound.io/.well-known/jwks`. 
 
-The `iss` and `aud` claims of an
-identity token should match the _issuer_ and _audience_ configured for the
-relying party. The `sub` should be a valid _subject_ based on the
-authored policy. For providers running in Upbound managed control planes, the
-_subject_ adheres to the following format.
+The `iss` and `aud` claims of an identity token should match the _issuer_ and _audience_ configured for the relying party. The `sub` should be a valid _subject_ based on the authored policy. For providers running in Upbound managed control planes, the _subject_ adheres to the following format.
 
 ```
 mcp:<account>/<mcp-name>:provider:<provider-name>
 ```
 
-For example, the following would be a valid _subject_ for `provider-aws` in a
-managed control plane named `prod-1` in the `my-org` account.
+For example, the following would be a valid _subject_ for `provider-aws` in a managed control plane named `prod-1` in the `my-org` account.
 
 ```
 mcp:my-org/prod-1:provider:provider-aws
 ```
 
-The claims for an identity token injected into the file system of a
-provider in a managed control plane looks like the following.
+The claims for an identity token injected into the file system of a provider in a managed control plane looks like the following.
 
 ```json
 {
@@ -141,54 +211,11 @@ provider in a managed control plane looks like the following.
 ```
 
 {{< hint "tip" >}} 
-Identity tokens injected into a provider `Pod` are valid
-for 1 hour. They are automatically refreshed before expiration to ensure there
-is no interruption in service. 
+Identity tokens injected into a provider `Pod` are valid for 1 hour. They are automatically refreshed before expiration to ensure there is no interruption in service. 
 {{< /hint >}}
 
+## Add Upbound OIDC to a Crossplane provider
 
-## Using Upbound OIDC as a credential source
+Any provider that can run in a managed control plane can support the `Upbound` credential source. Upbound injects identity tokens into the file system of every provider `Pod` whether they support OIDC or not. A provider wishing to support OIDC can access its identity token in the `/var/run/secrets/upbound.io/provider/token` file. 
 
-The Upbound console allows for creating instances of a `ProviderConfig` via the
-console, instead of manually authoring a YAML manifest. Users
-may also connect to their managed control planes directly and apply a
-`ProviderConfig` YAML manifest. 
-
-Each `Provider` defines their own `ProviderConfig` schema and values.
-
-{{<hint "tip" >}}
-Proividers in the [Upbound Marketplace](https://marketplace.upbound.io/) 
-contain examples of how to use `source: Upbound` to enable OIDC authentication.
-{{< /hint >}}
-
-For example, 
-[Upbound's GCP provider](https://marketplace.upbound.io/providers/upbound/provider-gcp/latest)
-includes the following manifest for using the `Upbound` OIDC identity source.
-
-```yaml
-apiVersion: gcp.upbound.io/v1beta1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  credentials:
-    source: Upbound
-    upbound:
-      federation:
-        providerID: projects/<project-id>/locations/global/workloadIdentityPools/<identity-pool>/providers/<identity-provider>
-        serviceAccount: <service-account-name>@<project-name>.iam.gserviceaccount.com
-  projectID: my-org-gcp-project
-```
-
-Applying this manifest in a
-managed control plane causes `provider-gcp` to fetch its identity token from
-the file system and use it to authenticate to GCP.
-
-## Adding Upbound OIDC to a Provider
-
-Any provider that can run in a managed control plane can support the `Upbound`
-credential source. Upbound injects identity tokens into the file system of every
-provider `Pod` whether they support OIDC or not. A provider wishing to support OIDC
-can access its identity token in the
-`/var/run/secrets/upbound.io/provider/token` file. [This Pull
-Request](https://github.com/upbound/provider-aws/pull/278) provides a reference implementation.
+View [this Pull Request](https://github.com/upbound/provider-aws/pull/278) for a reference implementation.

--- a/content/quickstart/gcp-deploy.md
+++ b/content/quickstart/gcp-deploy.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy your first control plane with GCP
-weight: 1
+weight: 3
 description: A guide for deploying a cloud platform on Upbound for Google GCP
 ---
 

--- a/content/quickstart/multicloud-deploy.md
+++ b/content/quickstart/multicloud-deploy.md
@@ -1,14 +1,14 @@
 ---
 title: Deploy your first multicloud control plane
-weight: 1
+weight: 4
 description: A guide for deploying a multicloud Cluster-as-a-Service platform on Upbound
 ---
 
-This quickstart guides you through how to create your first managed control plane in Upbound with configuration-caas. Connect Upbound to AWS, GCP, and Azure to provision and manage fully configured Kubernetes Service clusters, composed using cloud service primitives from the Upbound Official Providers.
+This quickstart guides you through how to create your first managed control plane in Upbound with configuration-caas. Connect Upbound to AWS, GCP, and Azure to provision and manage fully configured Kubernetes Service clusters. They're composed using cloud service primitives from the Upbound Official Providers.
 
 ## Prerequisites
 
-To deploy Upbound's configuration-caas, you will need:
+To deploy Upbound's configuration-caas, you need:
 
 * An Upbound account.
 * A GitHub account with permission to install GitHub Apps.
@@ -78,18 +78,18 @@ Select **Create Control Plane**.
 
 {{<img src="quickstart/images/caas-fre-step3.png" alt="Upbound Create Control Plane screen" quality="100" lightbox="true" size="medium" >}}
 
-### Finalize
+### Complete the flow
 
-On the final screen of the _Get Started_ experience, you can review your work so far to see the configuration you've cloned and the control plane you've created. This screen shows information about the providers that you will need to authenticate with after launching your new control plane.
-{{<img src="quickstart/images/caas-fre-step4.png" alt="Upbound Get Started Experience finalize step" quality="100" lightbox="true" size="medium" >}}
+On the final screen of the _Get Started_ experience, review your work. Observe the configuration you've cloned and the control plane you've created. This screen shows information about the providers that you need to authenticate with after launching your new control plane.
+{{<img src="quickstart/images/caas-fre-step4.png" alt="Upbound Get Started Experience final step" quality="100" lightbox="true" size="medium" >}}
 
 ## Welcome to the Upbound Console
 
-After completing the _Get Started_ experience, you are in the Upbound control plane explorer and will be greeted by a message with pointers for what to do next. 
+After completing the _Get Started_ experience, you are in the Upbound control plane explorer. The console shows a message with pointers for what to do next. 
 
 {{<img src="quickstart/images/caas-getting-started-guide.png" alt="Getting Started Guide" quality="100" align="center">}}
 
-You can retrigger this guide at any time by selecing the Getting Started Guide button in the upper right corner of the control plane explorer.
+You can reopen this guide at any time by selecting the Getting Started Guide button in the upper right corner of the control plane explorer.
 
 {{<img src="quickstart/images/caas-ctp-explorer.png" alt="Upbound control plane explorer" quality="100" align="center">}}
 
@@ -100,16 +100,17 @@ Read about the [Upbound Console]({{<ref "concepts/console">}}) for a full tour o
 {{< /hint >}}
 
 ## Authenticate with Providers
-Your next step is to configure provider-upbound and connect your managed control plane to each of the cloud service providers you wish to use in your CaaS offering. You will need to head to the command line to configure provider-upbound, but you can authenticate with cloud service providers from within the Upbound Console UI.
+Next, configure provider-upbound and connect your managed control plane to each cloud service provider you wish to use in your CaaS offering. You must configure provider-upbound via the CLI, but you can authenticate with cloud service providers from within the Upbound Console UI.
 
 {{< hint "tip" >}}
 You should wait until your Configuration has finished installing into your control plane before creating any ProviderConfigs.
 {{< /hint >}}
 
 ### Configure provider-upbound
-Provider Upbound needs a valid Upbound token to authenticate. There are multiple ways to acquire one but the simplest option is to log in with [Up CLI]({{<ref "reference/cli">}}) to get a session token. 
 
-Log in with the `up login` command to save a token to ~/.up/config.json
+Provider Upbound needs a valid Upbound token to authenticate. You can fetch one in multiple ways, but the simplest option is to log in with [Up CLI]({{<ref "reference/cli">}}) to get a session token. 
+
+Log in with the `up login` command to save a token to `~/.up/config.json`
 
 Then, create a Secret object that contains the token.
 
@@ -117,7 +118,7 @@ Then, create a Secret object that contains the token.
 kubectl -n crossplane-system create secret generic up-creds --from-file=creds=$HOME/.up/config.json
 ```
 
-Next, create a ProviderConfig object that references the Secret object you just created. The following command creates a ProviderConfig object that references the Secret object we just created.
+Next, create a ProviderConfig object that references the Secret object you just created. The following command creates a ProviderConfig object that references the Secret object you just created.
 
 ```shell
 cat <<EOF | kubectl apply -f -
@@ -186,11 +187,11 @@ You can find your AWS account ID by selecting the account dropdown in the upper 
 
 #### Provide the ARN to Upbound
 
-Return to Upbound and head to the Providers tab within the control plane explorer. Find provider-family-aws and click into the ProviderConfigs tab. Then, select **Create ProviderConfig**
+Return to Upbound and head to the Providers tab within the control plane explorer. Find provider-family-aws and select the ProviderConfigs tab. Then, select **Create ProviderConfig**
 
 {{<img src="quickstart/images/providers-tab.png" alt="Providers tab" quality="100" lightbox="true" size="medium">}}
 
-On the screen that displays, give the ProviderConfig a name. Entering the name `default` will set this as the default ProviderConfig for this provider in this control plane.
+On the screen that displays, give the ProviderConfig a name. Entering the name `default` sets this as the default ProviderConfig for this provider in this control plane.
 
 Next, paste the roleARN you copied from AWS into the input at the bottom of the form.  
 
@@ -271,11 +272,11 @@ For your control plane to be able to perform actions required by this configurat
 
 #### Finish configuring the Upbound identity provider
 
-Return to Upbound and head to the Providers tab within the control plane explorer. Find provider-family-azure and click into the ProviderConfigs tab. Then, select **Create ProviderConfig**
+Return to Upbound and head to the Providers tab within the control plane explorer. Find provider-family-azure and select the ProviderConfigs tab. Then, select **Create ProviderConfig**
 
 {{<img src="quickstart/images/providers-tab-aks.png" alt="Providers tab" quality="100" lightbox="true" size="medium">}}
 
-On the screen that displays, give the ProviderConfig a name. Entering the name `default` will set this as the default ProviderConfig for this provider in this control plane.
+On the screen that displays, give the ProviderConfig a name. Entering the name `default` sets this as the default ProviderConfig for this provider in this control plane.
 
 Next, scroll to the bottom of the form.  
 
@@ -425,9 +426,9 @@ Select **Enable**.
 
 #### Finish configuring the Upbound identity provider
 
-Return to Upbound and head to the Providers tab within the control plane explorer. Find provider-family-gcp and click into the ProviderConfigs tab. Then, select **Create ProviderConfig**
+Return to Upbound and head to the Providers tab within the control plane explorer. Find provider-family-gcp and select the ProviderConfigs tab. Then, select **Create ProviderConfig**
 
-On the screen that displays, give the ProviderConfig a name. Entering the name `default` will set this as the default ProviderConfig for this provider in this control plane.
+On the screen that displays, give the ProviderConfig a name. Entering the name `default` sets this as the default ProviderConfig for this provider in this control plane.
 
 Next, scroll past the instructions to the bottom of the form.  
 
@@ -449,7 +450,7 @@ The identity provider format is:
 
 <br />
 
-In the _serviceAccount_ field enter the **service account email**.
+In the _service Account_ field enter the **service account email**.
 
 In the _projectID_ field enter your **[GCP project ID](https://support.google.com/googleapi/answer/7014113)**.  
 


### PR DESCRIPTION
… to an external service by configuring ProviderConfigs, interacting wit multiple cloud accounts in a single service, and using Upbound Identity

