### PR TITLE
Remove support e-mail for community contributions

### DIFF
--- a/content/upbound-marketplace/packages.md
+++ b/content/upbound-marketplace/packages.md
@@ -95,7 +95,7 @@ For example, the Upbound AWS Official Provider is a `provider` package in the `u
 
 ### Publishing public packages
 
-Upbound reviews all public packages, and new repositories have a default publishing policy of requiring a one-time manual approval. Contact Upbound by emailing support@upbound.io or message the `#upbound` channel in the [Crossplane Slack](https://slack.crossplane.io/) to request Upbound to review your package.
+Upbound reviews all public packages, and new repositories have a default publishing policy of requiring a one-time manual approval. Contact our team via the `#upbound` channel in the [Crossplane Slack](https://slack.crossplane.io/) to request Upbound to review your package.
 
 Upbound needs the following information before considering a package:
 * Public Git repository of the package.

--- a/content/upbound-marketplace/packages.md
+++ b/content/upbound-marketplace/packages.md
@@ -95,7 +95,7 @@ For example, the Upbound AWS Official Provider is a `provider` package in the `u
 
 ### Publishing public packages
 
-Upbound reviews all public packages, and new repositories have a default publishing policy of requiring a one-time manual approval. Contact our team via the `#upbound` channel in the [Crossplane Slack](https://slack.crossplane.io/) to request Upbound to review your package.
+Upbound reviews all public packages, and new repositories have a default publishing policy of requiring a one-time manual approval. Contact the Upbound team via the `#upbound` channel in the [Crossplane Slack](https://slack.crossplane.io/) to request Upbound to review your package.
 
 Upbound needs the following information before considering a package:
 * Public Git repository of the package.


### PR DESCRIPTION
Per request, not routing community members through support if they need assistance to publish a package.