### PR TITLE
Add description metadata to pages missing descriptions

### DIFF
--- a/content/concepts/accounts/organizations.md
+++ b/content/concepts/accounts/organizations.md
@@ -1,5 +1,6 @@
 ---
 title: Organizations
+description: "Configuring Organizations for Upbound"
 ---
 
 Organizations allow multiple [user accounts]({{<ref "users" >}}) to share Upbound resources and collaborate.  

--- a/content/concepts/accounts/permissions.md
+++ b/content/concepts/accounts/permissions.md
@@ -1,5 +1,6 @@
 ---
 title: Permissions
+description: "Permission levels for Upbound organizations"
 ---
 
 Upbound's access model is organization-based. To perform an action within Upbound, users must belong to an organization that has the appropriate permissions.

--- a/content/concepts/accounts/robots.md
+++ b/content/concepts/accounts/robots.md
@@ -1,5 +1,6 @@
 ---
 title: Robots
+description: "Creating and assigning Upbound robot tokens"
 ---
 
 Robot accounts are non-user accounts with unique credentials and permissions. Organization _admins_ grant robot accounts access to individual repositories. Robot accounts access the repositories without using credentials tied to an individual user. 

--- a/content/concepts/accounts/teams.md
+++ b/content/concepts/accounts/teams.md
@@ -1,5 +1,6 @@
 ---
 title: "Teams"
+description: "Creating and managing Upbound teams"
 ---
 
 Teams are groups of Upbound [users]({{<ref "users" >}}) within an [organization]({{<ref "organizations" >}}). Teams provide more fine-grained permissions controls for users and robots accessing control planes and repositories.

--- a/content/concepts/accounts/users.md
+++ b/content/concepts/accounts/users.md
@@ -1,5 +1,6 @@
 ---
 title: "Users"
+description: "Creating and managing Upbound users"
 aliases:
     - "/users"
     - "/users/register"

--- a/content/providers/migration.md
+++ b/content/providers/migration.md
@@ -1,6 +1,7 @@
 ---
 title: "Migration tooling"
 weight: 40
+description: "How to automatically upgrade from legacy monolithic Providers to Upbound Provider families"
 aliases:
   - /knowledge-base/migrate-to-provider-families
 ---

--- a/content/providers/monolithic.md
+++ b/content/providers/monolithic.md
@@ -1,6 +1,7 @@
 ---
 title: "Monolithic providers"
 weight: 20
+description: "Support information for legacy monolithic Crossplane Providers"
 ---
 
 Upbound delivered the AWS, GCP and Azure official providers as a single 

--- a/content/providers/provider-families.md
+++ b/content/providers/provider-families.md
@@ -1,6 +1,7 @@
 ---
 title: "Provider families"
 weight: 10
+description: "Install and configure Crossplane Provider families"
 ---
 
 Upbound packages each of the official providers for Amazon AWS, Google GCP and Microsoft Azure as a "family." 

--- a/content/providers/support.md
+++ b/content/providers/support.md
@@ -1,7 +1,9 @@
 ---
 title: "Support and maintenance"
 weight: 30
+description: "The Upbound support policy for Official Providers"
 ---
+
 Official providers are open source and available to all Crossplane users.
 
 Support for official providers follows the [product lifecycle]({{<ref "reference/lifecycle">}}) and support policy of other Upbound components.

--- a/content/reference/cli/configuration.md
+++ b/content/reference/cli/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: "Configuration"
 metaTitle: "Upbound CLI - Configuration"
-metaDescription: "Configuration for the Upbound CLI"
+description: "Configuration for the Upbound CLI"
 weight: 105
 ---
 

--- a/content/reference/cli/rel-notes.md
+++ b/content/reference/cli/rel-notes.md
@@ -1,7 +1,7 @@
 ---
 title: "Release Notes"
 metaTitle: "Upbound CLI - Release Notes"
-metaDescription: "Release Notes for the up CLI"
+description: "Release Notes for the up CLI"
 weight: 200
 ---
 

--- a/content/reference/lifecycle.md
+++ b/content/reference/lifecycle.md
@@ -1,6 +1,7 @@
 ---
 title: Product Lifecycle
 weight: 100
+description: "Information on Upbound software versions and release policies" 
 ---
 
 ## Software list

--- a/content/reference/rel-notes.md
+++ b/content/reference/rel-notes.md
@@ -1,6 +1,7 @@
 ---
 title: Release Notes
 weight: 150
+description: "Release notes for Upbound Spaces" 
 ---
 
 Find below the changelog for Upbound the product and release notes for self-hosted feature of Upbound, [Spaces]({{< ref "spaces/overview.md" >}}).

--- a/content/upbound-marketplace/authentication.md
+++ b/content/upbound-marketplace/authentication.md
@@ -1,6 +1,7 @@
 ---
 title: "Authentication"
 weight: 10
+description: "How to authenticate to the Upbound Marketplace to access private packages."
 ---
 
 Pulling private packages or pushing packages to an Upbound Marketplace private repository requires authentication to Upbound.

--- a/content/upbound-marketplace/dmca.md
+++ b/content/upbound-marketplace/dmca.md
@@ -1,6 +1,7 @@
 ---
 title: "DMCA Policy"
 weight: 10000
+description: "Upbound Marketplace DMCA Policy"
 ---
 
 <!-- vale off -->

--- a/content/upbound-marketplace/packages.md
+++ b/content/upbound-marketplace/packages.md
@@ -1,6 +1,7 @@
 ---
 title: "Creating and Pushing Packages"
 weight: 30
+description: "How to create, configure and push packages to the Upbound Marketplace" 
 ---
 
 ## Package types

--- a/content/uxp/install.md
+++ b/content/uxp/install.md
@@ -1,6 +1,7 @@
 ---
 title: "Install UXP"
 weight: 205
+description: "How to install Upbound UXP"
 ---
 
 Upbound Universal Crossplane (UXP) is the Upbound official enterprise-grade

--- a/content/uxp/uninstall.md
+++ b/content/uxp/uninstall.md
@@ -1,6 +1,7 @@
 ---
 title: Uninstall UXP
 weight: 230
+description: "How to uninstall Upbound UXP"
 ---
 
 Uninstall UXP with `up uxp uninstall`.

--- a/content/uxp/upgrade.md
+++ b/content/uxp/upgrade.md
@@ -1,6 +1,7 @@
 ---
 title: "Upgrade UXP"
 weight: 210
+description: "How to uninstall Upbound UXP"
 ---
 
 Use the `up` command-line Upbound Universal Crossplane (UXP) to upgrade an existing install to a newer version or to upgrade from open source Crossplane.


### PR DESCRIPTION
Adds `description` front matter to all pages missing it. This improves SEO