### PR TITLE
lifecycle: clarify time span of support

### DIFF
--- a/content/reference/lifecycle.md
+++ b/content/reference/lifecycle.md
@@ -16,7 +16,7 @@ Upbound provides support and software maintenance to paid customers. Supported s
 
 <!-- vale Microsoft.Adverbs = NO --> 
 <!-- allow "Generally" -->
-Upbound supports Generally Available releases for up to 12 months. 
+Upbound supports Generally Available releases for a defined time span, depending on the release cycle of the respective component. See below for details.
 All software follows semantic versioning of `X.Y.Z`.
 <!-- vale Microsoft.Adverbs = NO --> 
 


### PR DESCRIPTION
The "up to 12 months" sounded like a promise, and with that it was contradicting the individual support time frame definition further town, especially UXP with only -2 UXP releases, not -3. 