### PR TITLE
Add documentation for migration to spaces

### DIFF
--- a/content/reference/cli/command-reference.md
+++ b/content/reference/cli/command-reference.md
@@ -1698,4 +1698,76 @@ Extract package contents into a Crossplane cache compatible format. Fetches from
 | `-o`       | `--output="out.gz"`   | Package output path. Extension must be `.gz`.         |
 {{< /table >}}
 
+<!-- vale Google.Headings = NO -->
+### alpha xpkg migration
+<!-- vale Google.Headings = YES -->
+
+Migrate a control plane to an Upbound Managed Control Plane.
+
+Use the 'migration' command to migrate control planes seamlessly from Crossplane or Universal Crossplane
+(XP/UXP) environments to Upbound's Managed Control Planes.
+
+<!-- vale Google.Headings = NO -->
+#### alpha xpkg migration export
+<!-- vale Google.Headings = YES -->
+
+Export the current state of a Crossplane or Universal Crossplane control plane into an archive, preparing it for
+migration to Upbound Managed Control Planes with `up alpha migration export`.
+
+The 'export' command exports the current state of a Crossplane or Universal Crossplane (xp/uxp) control plane
+into an archive file. You can then use this file for migration to Upbound Managed Control Planes.
+
+{{< table "table table-sm table-striped">}}
+| Short flag | Long flag   | Description                  |
+|------------|-------------|------------------------------|
+|            | `--kubeconfig=<path>`   | Use a custom `kubeconfig` file located at the given path. The default uses the active `kubeconfig`.         |
+|            | `--yes`     | When set to true, automatically accepts any confirmation prompts that may appear during the export process.         |
+| `-o`       | `--output`   | Specify the path for the exported archive. The default is 'xp-state.tar.gz'. |
+|            | `--include-extra-resources`   | A list of extra resource types to include in the export in "resource.group" format, along with all Crossplane resources. By default, it includes namespaces, configmaps, secrets.  |
+|            | `--exclude-resources`   | A list of resource types to exclude from the export in 'resource.group' format. No resources excluded by default. |
+|            | `--include-namespaces`   | A list of specific namespaces to include in the export. If not specified, all namespaces included by default. |
+|            | `--exclude-namespaces`   | A list of specific namespaces to exclude from the export. Defaults to 'kube-system', 'kube-public', 'kube-node-lease', and 'local-path-storage'. |
+|            | `--pause-before-export`   | When set to true, pauses all managed resources before starting the export process. This can help ensure a consistent state for the export. Defaults to 'false'. |
+{{< /table >}}
+
+**Examples**
+
+* Export the control plane state to a specified file 'xp-export.tar.gz'.
+
+  ```shell
+  up alpha migration export --output="xp-export.tar.gz"
+  ```
+* Pause all managed resources first and export the control plane state.
+
+  ```shell
+  up migration export --pause-before-export
+  ```
+
+* Export the control plane state with the extra resource specified and only using provided namespaces.
+
+  ```shell
+  up migration export --include-extra-resources="customresource.group" --include-namespaces="crossplane-system,team-a,team-b"
+  ```
+
+<!-- vale Google.Headings = NO -->
+#### alpha xpkg migration import
+<!-- vale Google.Headings = YES -->
+
+Import an exported control plane state into an Upbound managed control plane, completing the migration process.
+
+The 'import' command imports a control plane state from an archive file into an Upbound managed control plane.
+
+By default, the command pauses all managed resources during the import process for possible manual inspection/validation.
+You can use the `--unpause-after-import` flag to configure resuming all managed resources automatically after the
+import process completes.
+
+{{< table "table table-sm table-striped">}}
+| Short flag | Long flag   | Description                  |
+|------------|-------------|------------------------------|
+|            | `--kubeconfig=<path>`   | Use a custom `kubeconfig` file located at the given path. The default uses the active `kubeconfig`.         |
+|            | `--yes`     | When set to true, automatically accepts any confirmation prompts that may appear during the import process. |
+| `-i`       | `--input`   | Specifies the path of the archive to import. The default path is 'xp-state.tar.gz'.  |
+|            | `--unpause-after-import`   | When set to true, automatically resumes all managed resources paused during the import process. This helps in resuming normal operations post-import. Defaults to false, requiring manually resuming of resources if needed. |
+{{< /table >}}
+
 <!-- vale Google.Headings = YES -->

--- a/content/spaces/migrating-to-spaces.md
+++ b/content/spaces/migrating-to-spaces.md
@@ -1,0 +1,80 @@
+---
+title: Migrating to Spaces (alpha)
+weight: 100
+description: A guide to how to migrate to a managed control plane in a Space
+---
+
+{{< hint "important" >}}
+This functionality is in alpha maturity.
+{{< /hint >}}
+
+Upbound provides a migration tool to help you migrate your existing Crossplane control plane to a managed control plane
+in a Space. The migration tool is a CLI that you run locally with a two-step process, at a high level:
+
+1. Export your existing Crossplane control plane configuration/state into an archive file.
+2. Import the archive file into a managed control plane in a Space.
+
+The migration tool is available in the [up CLI]({{<ref "reference/cli/command-reference.md#alpha-xpkg-migration">}}) as
+`up alpha migration export` and `up alpha migration import` commands.
+
+## Prerequisites
+
+Before you begin, you must have the following:
+- A Spaces installation with version 1.2.0 or later.
+- The [up CLI]({{<ref "reference/cli/_index.md">}}) version 0.23.0 or later.
+
+### Migration process
+
+Below is a step-by-step guide to migrating your existing Crossplane control plane to a managed control plane in a Space.
+
+1. Run the following command to export your existing Crossplane control plane configuration/state into an archive file:
+
+    ```bash
+    up alpha migration export --kubeconfig <path-to-source-kubeconfig> --out <path-to-archive-file>
+    ```
+
+    The command exports your existing Crossplane control plane configuration/state into an archive file.
+
+    {{< hint "note" >}}
+    By default, the export command doesn't make any changes to your existing Crossplane control plane state, leaving it intact.
+    Use the `--pause-before-export` flag to pause the reconciliation on managed resources before exporting the archive file. 
+    {{< /hint >}}
+
+2. Use the control plane [create command]({{<ref "reference/cli/command-reference.md#controlplane-create">}}) to create a managed
+control plane in a Space:
+
+    ```bash
+    up controlplane create my-controlplane
+    ```
+
+3. Use the control plane [connect command]({{<ref "reference/cli/command-reference.md#controlplane-connect">}}) to connect to the
+managed control plane created in the previous step:
+
+    ```bash
+    up controlplane connect my-controlplane
+    ```
+
+    The command configures your local `kubeconfig` to connect to the managed control plane.
+
+4. Run the following command to import the archive file into the managed control plane:
+
+    ```bash
+    up alpha migration import --in <path-to-archive-file>
+    ```
+
+   {{< hint "note" >}}
+   By default, the import command leaves the control plane in an inactive state by pausing the reconciliation on managed
+   resources which gives you an opportunity to review the imported configuration/state before activating the control plane.
+   Use the `--unpause-after-import` flag to change the default behavior and activate the control plane immediately after
+   importing the archive file.
+   {{< /hint >}}
+
+5. At this point, you can review and validate the imported configuration/state, and then activate your managed
+   control plane by running the following command:
+
+    ```bash
+    kubectl annotate managed --all crossplane.io/paused-
+    ```
+
+   At this point, you can delete the source Crossplane control plane.
+ 

--- a/utils/vale/styles/Upbound/spelling-exceptions.txt
+++ b/utils/vale/styles/Upbound/spelling-exceptions.txt
@@ -10,6 +10,9 @@ CVEs
 Certwatcher
 Commonmark
 conformant
+ConfigMap
+ConfigMaps
+configmaps
 CRDs
 Crossplane
 Crossplane's


### PR DESCRIPTION
This PR:
- Documents the new alpha migration commands introduced with [this PR](https://github.com/upbound/up/pull/409).
- Adds a guide for migrating control planes to spaces.