### PR TITLE
Update kind-quickstart.md

### DIFF
--- a/content/spaces/kind-quickstart.md
+++ b/content/spaces/kind-quickstart.md
@@ -34,7 +34,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration


### PR DESCRIPTION
Locking kind image version to 1.27 is no longer needed.

