### PR TITLE
Update helm-based Spaces Quickstart

### DIFF
--- a/content/spaces/quickstart/_index.md
+++ b/content/spaces/quickstart/_index.md
@@ -499,6 +499,12 @@ helm -n upbound-system upgrade --install spaces \
   --wait
 ```
 
+Create an up CLI profile for the Space
+
+```bash
+up profile set space --profile new-profile-name --account "${UPBOUND_ACCOUNT}"
+```
+
 {{< /tab >}}
 
 {{< /tabs >}}


### PR DESCRIPTION
Add an example command to create a new up CLI profile after installing spaces with helm, which is done automatically if using `up space init` and is necessary for things like `up ctp list` and `up ctp connect`

