### PR TITLE
Update AWS authentication.md runtimeConfigRef name

### DIFF
--- a/content/providers/provider-aws/authentication.md
+++ b/content/providers/provider-aws/authentication.md
@@ -480,7 +480,7 @@ The {{<hover label="cc" line="7">}}spec{{</hover>}} is empty.
 apiVersion: pkg.crossplane.io/v1beta1
 kind: DeploymentRuntimeConfig
 metadata:
-  name: irsa-controllerconfig
+  name: irsa-runtimeconfig
 spec:
   serviceAccountTemplate:
     metadata:


### PR DESCRIPTION
This PR https://github.com/upbound/docs/pull/272 updated from `ControllerConfig` named `irsa-controllerconfig ` to `DeploymentRuntimeConfig` named `irsa-runtimeconfig `.

There is one reference that wasn't updated. Fixing that here.
