### PR TITLE
Feature/proxied environments

### DIFF
--- a/content/spaces/quickstart/_index.md
+++ b/content/spaces/quickstart/_index.md
@@ -357,7 +357,9 @@ helm upgrade --install crossplane universal-crossplane \
   --wait
 ```
 
+<!-- vale Upbound.Spelling  = NO -->
 If your company uses a proxied environment with mirrored registries, please update the specified registry to your internal registry.
+<!-- vale Upbound.Spelling  = YES -->
 
 ```bash
 helm upgrade --install crossplane universal-crossplane \

--- a/content/spaces/quickstart/_index.md
+++ b/content/spaces/quickstart/_index.md
@@ -357,9 +357,9 @@ helm upgrade --install crossplane universal-crossplane \
   --wait
 ```
 
-<!-- vale Upbound.Spelling  = NO -->
+<!-- vale upbound.Spelling  = NO -->
 If your company uses a proxied environment with mirrored registries, please update the specified registry to your internal registry.
-<!-- vale Upbound.Spelling  = YES -->
+<!-- vale upbound.Spelling  = YES -->
 
 ```bash
 helm upgrade --install crossplane universal-crossplane \
@@ -514,9 +514,9 @@ helm -n upbound-system upgrade --install spaces \
   --wait
 ```
 
-<!-- vale Upbound.Spelling  = NO -->
+<!-- vale upbound.Spelling  = NO -->
 If your company uses a proxied environment with mirrored registries, please update the specified registry to your internal registry.
-<!-- vale Upbound.Spelling  = YES -->
+<!-- vale upbound.Spelling  = YES -->
 
 
 ```bash

--- a/content/spaces/quickstart/_index.md
+++ b/content/spaces/quickstart/_index.md
@@ -364,7 +364,7 @@ helm upgrade --install crossplane universal-crossplane \
   --repo https://charts.upbound.io/stable \
   --namespace upbound-system --create-namespace \
   --version v1.15.2-up.1 \
-  --set "args={--enable-usages,--max-reconcile-rate=1000,--registry=registry.company.corp}" \
+  --set "args={--enable-usages,--max-reconcile-rate=1000,--registry=registry.company.corp/xpkg.upbound.io}" \
   --set resourcesCrossplane.requests.cpu="500m" --set resourcesCrossplane.requests.memory="1Gi" \
   --set resourcesCrossplane.limits.cpu="1000m" --set resourcesCrossplane.limits.memory="2Gi" \
   --wait
@@ -521,7 +521,9 @@ helm -n upbound-system upgrade --install spaces \
   --set "ingress.host=${SPACES_ROUTER_HOST}" \
   --set "clusterType=${SPACES_CLUSTER_TYPE}" \
   --set "account=${UPBOUND_ACCOUNT}" \
-  --set "controlPlanes.uxp.registryOverride=registry.company.corp" \
+  --set "registry=registry.company.corp/us-west1-docker.pkg.dev/orchestration-build/upbound-environments" \
+  --set "controlPlanes.uxp.registryOverride=registry.company.corp/xpkg.upbound.io" \
+  --set "controlPlanes.uxp.repository=registry.company.corp/charts.upbound.io/stable" \
   --wait
 ```
 

--- a/content/spaces/quickstart/_index.md
+++ b/content/spaces/quickstart/_index.md
@@ -350,8 +350,21 @@ Install Upbound Universal Crossplane (UXP)
 helm upgrade --install crossplane universal-crossplane \
   --repo https://charts.upbound.io/stable \
   --namespace upbound-system --create-namespace \
-  --version v1.14.6-up.1 \
+  --version v1.15.2-up.1 \
   --set "args={--enable-usages,--max-reconcile-rate=1000}" \
+  --set resourcesCrossplane.requests.cpu="500m" --set resourcesCrossplane.requests.memory="1Gi" \
+  --set resourcesCrossplane.limits.cpu="1000m" --set resourcesCrossplane.limits.memory="2Gi" \
+  --wait
+```
+
+If your company uses a proxied environment with mirrored registries, please update the specified registry to your internal registry.
+
+```bash
+helm upgrade --install crossplane universal-crossplane \
+  --repo https://charts.upbound.io/stable \
+  --namespace upbound-system --create-namespace \
+  --version v1.15.2-up.1 \
+  --set "args={--enable-usages,--max-reconcile-rate=1000,--registry=registry.company.corp}" \
   --set resourcesCrossplane.requests.cpu="500m" --set resourcesCrossplane.requests.memory="1Gi" \
   --set resourcesCrossplane.limits.cpu="1000m" --set resourcesCrossplane.limits.memory="2Gi" \
   --wait
@@ -370,7 +383,7 @@ kind: Provider
 metadata:
   name: provider-kubernetes
 spec:
-  package: "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.12.1"
+  package: "crossplane-contrib/provider-kubernetes:v0.12.1"
   runtimeConfigRef:
     name: provider-kubernetes
 ---
@@ -388,7 +401,7 @@ kind: Provider
 metadata:
   name: provider-helm
 spec:
-  package: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.17.0"
+  package: "crossplane-contrib/provider-helm:v0.17.0"
   runtimeConfigRef:
     name: provider-helm
 ---

--- a/content/spaces/quickstart/_index.md
+++ b/content/spaces/quickstart/_index.md
@@ -512,6 +512,20 @@ helm -n upbound-system upgrade --install spaces \
   --wait
 ```
 
+If your company uses a proxied environment with mirrored registries, please update the specified registry to your internal registry.
+
+```bash
+helm -n upbound-system upgrade --install spaces \
+  oci://us-west1-docker.pkg.dev/orchestration-build/upbound-environments/spaces \
+  --version "${SPACES_VERSION}" \
+  --set "ingress.host=${SPACES_ROUTER_HOST}" \
+  --set "clusterType=${SPACES_CLUSTER_TYPE}" \
+  --set "account=${UPBOUND_ACCOUNT}" \
+  --set "controlPlanes.uxp.registryOverride=registry.company.corp" \
+  --wait
+```
+
+
 Create an up CLI profile for the Space
 
 ```bash

--- a/content/spaces/quickstart/_index.md
+++ b/content/spaces/quickstart/_index.md
@@ -514,7 +514,10 @@ helm -n upbound-system upgrade --install spaces \
   --wait
 ```
 
+<!-- vale Upbound.Spelling  = NO -->
 If your company uses a proxied environment with mirrored registries, please update the specified registry to your internal registry.
+<!-- vale Upbound.Spelling  = YES -->
+
 
 ```bash
 helm -n upbound-system upgrade --install spaces \

--- a/content/spaces/quickstart/_index.md
+++ b/content/spaces/quickstart/_index.md
@@ -357,9 +357,9 @@ helm upgrade --install crossplane universal-crossplane \
   --wait
 ```
 
-<!-- vale upbound.Spelling  = NO -->
+<!-- vale off -->
 If your company uses a proxied environment with mirrored registries, please update the specified registry to your internal registry.
-<!-- vale upbound.Spelling  = YES -->
+<!-- vale on -->
 
 ```bash
 helm upgrade --install crossplane universal-crossplane \
@@ -514,9 +514,9 @@ helm -n upbound-system upgrade --install spaces \
   --wait
 ```
 
-<!-- vale upbound.Spelling  = NO -->
+<!-- vale off -->
 If your company uses a proxied environment with mirrored registries, please update the specified registry to your internal registry.
-<!-- vale upbound.Spelling  = YES -->
+<!-- vale on -->
 
 
 ```bash


### PR DESCRIPTION
- bump uxp to v1.15.x to use registry feature
- remove registry from provider manifests
- add options to specify crossplane registry to install functions, providers, configurations from internal / other registries than xpkg.upbound.io