### PR TITLE
fixing missing upbound pre-install instructions for azure

### DIFF
--- a/content/all-spaces/disconnected-spaces/azure-deployment.md
+++ b/content/all-spaces/disconnected-spaces/azure-deployment.md
@@ -86,7 +86,7 @@ export SPACES_TOKEN_PATH="$@/path/to/token.json$@"
 Set the version of Spaces software you want to install.
 
 ```ini
-export SPACES_VERSION=1.4.0
+export SPACES_VERSION=1.4.2
 ```
 
 Set the router host and cluster type. The `SPACES_ROUTER_HOST` is the domain name that's used to access the control plane instances. It's used by the ingress controller to route requests.


### PR DESCRIPTION
Added missing pre-install instructions to configure environment variables used during setup on Azure.