### PR TITLE
Update _index.md

### DIFF
--- a/content/all-spaces/disconnected-spaces/quickstart/_index.md
+++ b/content/all-spaces/disconnected-spaces/quickstart/_index.md
@@ -116,7 +116,7 @@ up ctp list
 Connect to your managed control plane with the `up ctx` command. With your kubeconfig still pointed at the Kubernetes cluster where you installed the Upbound Space, run the following:
 
 ```bash
-up ctx default/ctp1
+up ctx ./default/ctp1
 ```
 
 This command updates your current kubecontext. You're now connected to your managed control plane directly. Confirm this is the case by trying to list the CRDs in your managed control plane:


### PR DESCRIPTION
With up v0.30.0+, we need to fix how to use `ctx` to reference a control plane to connect to it

