### PR TITLE
MCP connector release notes for v0.6.0 and v0.6.1

### DIFF
--- a/content/mcp/ctp-connector.md
+++ b/content/mcp/ctp-connector.md
@@ -95,17 +95,7 @@ kubectl api-resources
 
 #### With Helm
 
-The MCP Connector is also available as a Helm chart. First add the Upbound beta repository with the `helm repo add` command.
-
-```bash
-helm repo add upbound-beta https://charts.upbound.io/beta
-```
-
-Update the local Helm chart cache with `helm repo update`.
-
-```bash
-helm repo update
-```
+The MCP Connector is also available as a Helm chart, available at `oci://xpkg.upbound.io/spaces-artifacts/mcp-connector`.
 
 Install the MCP Connector Helm chart with `helm install`. Make sure to update the chart values with your own. It's recommended you create a values file called `connector-values.yaml` and provide the following below. Select the tab according to which environment your managed control plane is running in.
 
@@ -157,7 +147,7 @@ spaces:
 Provide the values file above when you `helm install` the MCP Connector:
 
 ```bash
-helm install --wait mcp-connector upbound-beta/mcp-connector -n kube-system -f connector-values.yaml
+helm install --wait mcp-connector oci://xpkg.upbound.io/spaces-artifacts/mcp-connector -n kube-system -f connector-values.yaml
 ```
 
 {{<hint "tip" >}}

--- a/content/reference/rel-notes.md
+++ b/content/reference/rel-notes.md
@@ -195,6 +195,23 @@ Released August 28th, 2023.
 
 ## Control plane connector release notes
 
+### MCP connector v0.6.1
+
+Released June 29th, 2024.
+
+#### What's Changed
+
+- Fixed a regression where connector makes only a single kind for a given group/version available to the application cluster.
+
+### MCP connector v0.6.0
+
+Released June 15th, 2024.
+
+#### What's Changed
+
+- We started shipping the helm chart as an OCI artifact in the Upbound registry, available at `oci://xpkg.upbound.io/spaces-artifacts/mcp-connector`.
+- This the latest release where we will publish the helm chart to the Upbound helm repository, please migrate to the OCI artifact.
+
 ### MCP connector v0.5.0
 
 Released June 6th, 2024.


### PR DESCRIPTION
Adds release notes for MCP connector v0.6.0 and v0.6.1 releases. It also updates helm installation to use the OCI artifact.