### PR TITLE
fix: backup ttl expects duration

### DIFF
--- a/content/all-spaces/backup-and-restore.md
+++ b/content/all-spaces/backup-and-restore.md
@@ -232,7 +232,7 @@ kind: SharedBackupSchedule
 metadata:
   name: daily-schedule
 spec:
-  ttl: 604800 # Backup is garbage collected after 7 days
+  ttl: 168h # Backup is garbage collected after 7 days
 ```
 
 ### Garbage collect backups when the schedule gets deleted
@@ -336,7 +336,7 @@ kind: SharedBackup
 metadata:
   name: my-backup
 spec:
-  ttl: 604800 # Backup is garbage collected after 7 days
+  ttl: 168h # Backup is garbage collected after 7 days
 ```
 
 <!-- vale off -->
@@ -457,7 +457,7 @@ kind: Backup
 metadata:
   name: my-backup
 spec:
-  ttl: 604800 # Backup is garbage collected after 7 days
+  ttl: 168h # Backup is garbage collected after 7 days
 ```
 
 ## Restore a control plane from a backup


### PR DESCRIPTION
Backups' TTL expects a duration, examples provided wrongly set an integer instead. Converted to hours for brevity.