### PR TITLE
document in-chart postgres instance for query API

### DIFF
--- a/content/all-spaces/query-api/_index.md
+++ b/content/all-spaces/query-api/_index.md
@@ -25,7 +25,7 @@ up space init --token-file="${SPACES_TOKEN_PATH}" "v${SPACES_VERSION}" \
   --set "features.alpha.apollo.storage.postgres.create=true"
 ```
 
-This will directly create a PostgreSQL cluster handled by [CloudNativePG](https://cloudnative-pg.io).
+These flags create a PostgreSQL cluster handled by [CloudNativePG](https://cloudnative-pg.io).
 
 Users can also provide their own instance if needed, by setting `features.alpha.apollo.storage.postgres.create=false` and providing all the required information at `features.alpha.apollo.storage.postgres.connection`.
 


### PR DESCRIPTION
Follow up to https://github.com/upbound/up-private/pull/58 and https://github.com/upbound/spaces/pull/1829, part of https://github.com/upbound/team-control-planes/issues/1064.

Will only work from 1.8, so we should wait to merge this.