### PR TITLE
Document `up version` command and remove `--version` flag

### DIFF
--- a/content/reference/cli/command-reference.md
+++ b/content/reference/cli/command-reference.md
@@ -561,12 +561,11 @@ storeconfigs                                             secrets.crossplane.io/v
 **Options:**
 
 {{< table "table table-sm table-striped cli-ref">}}
-| Long flag                 | Short flag | Description                                                         | Default Value         |
-|---------------------------|-----------|---------------------------------------------------------------------|-----------------------|
-
-| short                     | s         | Short output.                                                       |                       |
-| context                   |           | Kubernetes context to operate on.                                   | upbound               |
-| kubeconfig                | f         | Kubeconfig to modify when saving a new context. `-f -` prints to stout.                      |         
+| Long flag  | Short flag | Description                                                             | Default Value |
+| ---------- | ---------- | ----------------------------------------------------------------------- | ------------- |
+| short      | `-s`       | Short output.                                                           |               |
+| context    |            | Kubernetes context to operate on.                                       | upbound       |
+| kubeconfig | `-f`       | Kubeconfig to modify when saving a new context. `-f -` prints to stout. |               |
 {{< /table >}}
 
 ## license


### PR DESCRIPTION
I noticed that `up` didn't have a `--version` flag, but a `version` command. I placed `up version` section in its alphabetical order, but placing it at the top might be better.