### PR TITLE
Add release notes for mcp connector v0.8.0

### DIFF
--- a/content/reference/rel-notes.md
+++ b/content/reference/rel-notes.md
@@ -391,6 +391,14 @@ Released August 28th, 2023.
 
 ## Control plane connector release notes
 
+### MCP connector v0.8.0
+
+Released November 1st, 2024.
+
+#### What's Changed
+
+- Ability to override app cluster id via `clusterID` helm value for migration scenarios.
+
 ### MCP connector v0.7.0
 
 Released August 16th, 2024.


### PR DESCRIPTION
Adds release notes for mcp connector [v0.8.0](https://github.com/upbound/mcp-connector/releases/tag/v0.8.0)