### PR TITLE
Remove references to unused SPACES_CLUSTER_TYPE parameter

### DIFF
--- a/content/all-spaces/observability.md
+++ b/content/all-spaces/observability.md
@@ -50,7 +50,6 @@ helm -n upbound-system upgrade --install spaces \
   oci://xpkg.upbound.io/spaces-artifacts/spaces \
   --version "${SPACES_VERSION}" \
   --set "ingress.host=${SPACES_ROUTER_HOST}" \
-  --set "clusterType=${SPACES_CLUSTER_TYPE}" \
   --set "account=${UPBOUND_ACCOUNT}" \
   --set "features.alpha.observability.enabled=true" \
   --wait

--- a/content/all-spaces/self-hosted-spaces/aws-deployment.md
+++ b/content/all-spaces/self-hosted-spaces/aws-deployment.md
@@ -117,13 +117,6 @@ export SPACES_ROUTER_HOST="$@proxy.upbound-127.0.0.1.nip.io$@"
 Make sure to replace the placeholder text in `SPACES_ROUTER_HOST` and provide a real domain that you own.
 {{< /hint >}}
 
-The `SPACES_CLUSTER_TYPE` is the Kubernetes cluster provider you configured in the previous step.
-
-
-```ini
-export SPACES_CLUSTER_TYPE=eks
-```
-
 <!-- vale off -->
 ## Install the Spaces software
 <!-- vale on -->
@@ -192,7 +185,6 @@ helm -n upbound-system upgrade --install spaces \
   oci://xpkg.upbound.io/spaces-artifacts/spaces \
   --version "${SPACES_VERSION}" \
   --set "ingress.host=${SPACES_ROUTER_HOST}" \
-  --set "clusterType=${SPACES_CLUSTER_TYPE}" \
   --set "account=${UPBOUND_ACCOUNT}" \
   --set "authentication.hubIdentities=true" \
   --set "authorization.hubRBAC=true" \

--- a/content/all-spaces/self-hosted-spaces/azure-deployment.md
+++ b/content/all-spaces/self-hosted-spaces/azure-deployment.md
@@ -101,13 +101,6 @@ export SPACES_ROUTER_HOST="$@proxy.upbound-127.0.0.1.nip.io$@"
 Make sure to replace the placeholder text in `SPACES_ROUTER_HOST` and provide a real domain that you own.
 {{< /hint >}}
 
-The `SPACES_CLUSTER_TYPE` is the Kubernetes cluster provider you configured in the previous step.
-
-
-```ini
-export SPACES_CLUSTER_TYPE=aks
-```
-
 <!-- vale off -->
 ## Install the Spaces software
 <!-- vale on -->
@@ -160,7 +153,6 @@ helm -n upbound-system upgrade --install spaces \
   oci://xpkg.upbound.io/spaces-artifacts/spaces \
   --version "${SPACES_VERSION}" \
   --set "ingress.host=${SPACES_ROUTER_HOST}" \
-  --set "clusterType=${SPACES_CLUSTER_TYPE}" \
   --set "account=${UPBOUND_ACCOUNT}" \
   --set "authentication.hubIdentities=true" \
   --set "authorization.hubRBAC=true" \

--- a/content/all-spaces/self-hosted-spaces/gcp-deployment.md
+++ b/content/all-spaces/self-hosted-spaces/gcp-deployment.md
@@ -99,14 +99,6 @@ export SPACES_ROUTER_HOST="$@proxy.upbound-127.0.0.1.nip.io$@"
 Make sure to replace the placeholder text in `SPACES_ROUTER_HOST` and provide a real domain that you own.
 {{< /hint >}}
 
-The `SPACES_CLUSTER_TYPE` is the Kubernetes cluster provider you configured in the previous step.
-
-
-```ini
-export SPACES_CLUSTER_TYPE=gke
-```
-
-
 <!-- vale off -->
 ## Install the Spaces software
 <!-- vale on -->
@@ -158,7 +150,6 @@ helm -n upbound-system upgrade --install spaces \
   oci://xpkg.upbound.io/spaces-artifacts/spaces \
   --version "${SPACES_VERSION}" \
   --set "ingress.host=${SPACES_ROUTER_HOST}" \
-  --set "clusterType=${SPACES_CLUSTER_TYPE}" \
   --set "account=${UPBOUND_ACCOUNT}" \
   --set "authentication.hubIdentities=true" \
   --set "authorization.hubRBAC=true" \

--- a/content/all-spaces/self-hosted-spaces/proxies-config.md
+++ b/content/all-spaces/self-hosted-spaces/proxies-config.md
@@ -17,7 +17,6 @@ helm -n upbound-system upgrade --install spaces \
   oci://xpkg.upbound.io/spaces-artifacts/spaces \
   --version "${SPACES_VERSION}" \
   --set "ingress.host=${SPACES_ROUTER_HOST}" \
-  --set "clusterType=${SPACES_CLUSTER_TYPE}" \
   --set "account=${UPBOUND_ACCOUNT}" \
   --set "authentication.hubIdentities=true" \
   --set "authorization.hubRBAC=true" \

--- a/content/all-spaces/self-hosted-spaces/use-argo-flux.md
+++ b/content/all-spaces/self-hosted-spaces/use-argo-flux.md
@@ -52,7 +52,6 @@ helm -n upbound-system upgrade --install spaces \
   oci://xpkg.upbound.io/spaces-artifacts/spaces \
   --version "${SPACES_VERSION}" \
   --set "ingress.host=${SPACES_ROUTER_HOST}" \
-  --set "clusterType=${SPACES_CLUSTER_TYPE}" \
   --set "account=${UPBOUND_ACCOUNT}" \
   --set "features.alpha.argocdPlugin.enabled=true" \
   --set "features.alpha.argocdPlugin.useUIDFormatForCTPSecrets=true" \
@@ -103,7 +102,6 @@ helm -n upbound-system upgrade --install spaces \
   oci://xpkg.upbound.io/spaces-artifacts/spaces \
   --version "${SPACES_VERSION}" \
   --set "ingress.host=${SPACES_ROUTER_HOST}" \
-  --set "clusterType=${SPACES_CLUSTER_TYPE}" \
   --set "account=${UPBOUND_ACCOUNT}" \
   --set "features.alpha.argocdPlugin.enabled=true" \
   --set "features.alpha.argocdPlugin.useUIDFormatForCTPSecrets=true" \
@@ -123,7 +121,6 @@ helm -n upbound-system upgrade --install spaces \
   oci://xpkg.upbound.io/spaces-artifacts/spaces \
   --version "${SPACES_VERSION}" \
   --set "ingress.host=${SPACES_ROUTER_HOST}" \
-  --set "clusterType=${SPACES_CLUSTER_TYPE}" \
   --set "account=${UPBOUND_ACCOUNT}" \
   --set "features.alpha.argocdPlugin.enabled=true" \
   --set "features.alpha.argocdPlugin.useUIDFormatForCTPSecrets=true" \


### PR DESCRIPTION
Cluster type is no longer part of the runtime for spaces, and does not need to be in the docs.