### PR TITLE
make resource.respectRBAC Argo CD configuration change visible in release notes

### DIFF
--- a/content/reference/rel-notes.md
+++ b/content/reference/rel-notes.md
@@ -64,7 +64,7 @@ Due to a technical glitch there was no 1.9.0 release image, and the first one av
 {{< /hint >}}
 
 {{< hint "warning" >}}
-Starting with Spaces 1.9.x, Spaces with Gitops integration with Argo CD must update their Argo CD ConfigMap to include `resource.respectRBAC: normal` instead of explicit `resource.exclusions`. Please check [Configure Argo CD]({{<ref "mcp/gitops.md#configure-argo-cd" >}}) section for instructions and details.
+Starting with Spaces 1.9.x, Spaces with an  Argo CD Gitops integration must update their Argo CD ConfigMap to include `resource.respectRBAC: normal` instead of explicit `resource.exclusions`. Please check [Configure Argo CD]({{<ref "mcp/gitops.md#configure-argo-cd" >}}) section for instructions and details.
 {{< /hint >}}
 
 #### Features and Enhancements


### PR DESCRIPTION
makes resource.respectRBAC Argo CD configuration change visible in release notes

https://github.com/upbound/docs/pull/501 introduced documentation for Argo CD configuration `resource.respectRBAC`, which is a breaking change for ArgoCD integrations at Spaces 1.9.x
These should be added to Release notes for better visibility.

Relevant slack discussion:
https://upboundio.slack.com/archives/C075C9ZMSQG/p1733781854965809