### PR TITLE
kubectl ctp to kubectl controlplanes.spaces.upbound.io

### DIFF
--- a/content/all-spaces/self-hosted-spaces/troubleshooting.md
+++ b/content/all-spaces/self-hosted-spaces/troubleshooting.md
@@ -106,7 +106,7 @@ kubectl get ctp
 ```
 3. Describe the control plane by providing its name, found in the preceding instruction.
 ```bash
-kubectl describe ctp <control-plane-name>
+kubectl describe controlplanes.spaces.upbound.io <control-plane-name>
 ```
 
 ## Issues

--- a/content/mcp/auto-upgrade.md
+++ b/content/mcp/auto-upgrade.md
@@ -89,7 +89,7 @@ example-ctp    1.11.5-up.1          False       True              31m
 For more information, use the `-o yaml` flag to return more information.
 
 ```bash
-kubectl get ctp example-ctp -o yaml
+kubectl get controlplanes.spaces.upbound.io example-ctp -o yaml
 status:
 conditions:
 ...

--- a/content/mcp/git-integration.md
+++ b/content/mcp/git-integration.md
@@ -48,7 +48,7 @@ In the preceding example:
 Once your control plane is in a `Ready` state, it pulls manifests from the repository configured in `spec.source`. The control plane object contains emitted sync events, which you can find by describing the control plane:
 
 ```bash
-kubectl describe ctp example-ctp
+kubectl describe controlplanes.spaces.upbound.io example-ctp
 ```
 
 ## How to use control plane source


### PR DESCRIPTION
`kubectl ctp ...` does not work for control planes anymore because there is a CRD with a higher priority introduced (clienttrafficpolicies.gateway.envoyproxy.io)  with the same short name in v1.10.0. 

```bash
$ k get ctp -A
Warning: short name "ctp" could also match lower priority resource controlplanes.spaces.upbound.io
```

Changed examples in docs to use the full CRD name.

