### PR TITLE
Add `type: Prefix` to pull-secrets doc

### DIFF
--- a/content/providers/pull-secrets.md
+++ b/content/providers/pull-secrets.md
@@ -46,6 +46,7 @@ metadata:
 spec:
   matchImages:
     - prefix: xpkg.upbound.io/upbound
+      type: Prefix
   registry:
     authentication:
       pullSecretRef:


### PR DESCRIPTION
When people are running the configuration for ImageConfig together with argo, argo will constantly reconcile because it tries to remove the default `type: Prefix`. If we add it here it will work for people using argo out of the box. Reporte by volvo.