### PR TITLE
Update Query API docs to v1alpha2

### DIFF
--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/description.yaml
@@ -1,2 +1,2 @@
 description: |-
-    GroupQuery represents a query against a group of controlplanes.
+    GroupQuery represents a query against a group of control planes.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/objects/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/objects/description.yaml
@@ -1,2 +1,4 @@
 description: |-
     objects is the list of objects returned by the query.
+    
+    Objects is mutual exclusive with Tables.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/objects/items/properties/$errors/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/objects/items/properties/$errors/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    errors is the list of errors that occurred while processing the object.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/objects/items/properties/$errors/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/objects/items/properties/$errors/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    tables is the list of tables returned by the query. Objects are grouped
+    as specified in the query. Hence, potentially multiple tables are returned.
+    
+    Objects is mutual exclusive with Tables.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    QueryResponseTable is a table representation of a set of API resources.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    columns is the list of columns in the table.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    TableColumnDefinition contains information about a column returned in the Table.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/properties/description/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/properties/description/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    description is a human readable description of this column.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/properties/format/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/properties/format/description.yaml
@@ -1,0 +1,6 @@
+description: |-
+    format is an optional OpenAPI type modifier for this column. A format modifies the type and
+    imposes additional rules, like date or time formatting for a string. The 'name' format is applied
+    to the primary identifier column which has type 'string' to assist in clients identifying column
+    is the resource name.
+    See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/properties/name/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/properties/name/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    name is a human readable name for the column.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/properties/priority/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/properties/priority/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    priority is an integer defining the relative importance of this column compared to others. Lower
+    numbers are considered higher priority. Columns that may be omitted in limited space scenarios
+    should be given a higher priority.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/properties/type/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/columns/items/properties/type/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    type is an OpenAPI type definition for this column, such as number, integer, string, or
+    array.
+    See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/groupVersionKind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/groupVersionKind/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    groupVersionKind is the group, version, and kind of the objects in the table.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/group/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/kind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/kind/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/version/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/version/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    rows is the list of rows in the table.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    TableRow is an individual row in a table.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/cells/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/cells/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    cells will be as wide as the column definitions array and may contain strings, numbers (float64 or
+    int64), booleans, simple maps, lists, or null. See the type field of the column definition for a
+    more detailed description.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/cells/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/cells/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    conditions describe additional status of a row that are relevant for a human user. These conditions
+    apply to the row, not to the object, and will be specific to table output. The only defined
+    condition type is 'Completed', for a row that indicates a resource that has run to completion and
+    can be given less visual priority.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    TableRowCondition allows a row to be marked with additional information.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/message/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/message/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    Human readable message indicating details about last transition.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/reason/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/reason/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    (brief) machine readable reason for the condition's last transition.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/status/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/status/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    Status of the condition, one of True, False, Unknown.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/type/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/type/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    Type of row condition. The only defined value is 'Completed' indicating that the
+    object this row represents has reached a completed state and may be given less visual
+    priority than other rows. Clients are not required to honor any conditions but should
+    be consistent where possible about handling the conditions.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/object/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/response/properties/tables/items/properties/rows/items/properties/object/description.yaml
@@ -1,0 +1,7 @@
+description: |-
+    This field contains the requested additional information about each object based on the includeObject
+    policy when requesting the Table. If 'None', this field is empty, if 'Object' this will be the
+    default serialization of the object for the current API version, and if 'Metadata' (the default) will
+    contain the object metadata. Check the returned kind and apiVersion of the object before parsing.
+    The media type of the object will always match the enclosing list - if this as a JSON table, these
+    will be JSON encoded objects.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/controlPlane/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/controlPlane/description.yaml
@@ -1,3 +1,3 @@
 description: |-
-    controlPlane specifies which controlplanes to query. If empty, all
-    controlplanes are queried in the given scope.
+    controlPlane specifies which control planes to query. If empty, all
+    control planes are queried in the given scope.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/controlPlane/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/controlPlane/properties/group/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    group is the group of the control plane to query. If empty, all groups
+    are queried in the given scope.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/controlPlane/properties/name/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/controlPlane/properties/name/description.yaml
@@ -1,3 +1,3 @@
 description: |-
-    name is the name of the controlplane to query. If empty, all controlplanes
+    name is the name of the control plane to query. If empty, all control planes
     are queried in the given scope.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    objects specifies what to filter. Objects in the query response will
+    match all criteria in at least one of the specified filters.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    QueryFilter specifies what to filter. Objects in the query response will
+    match all criteria specified in the filter.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/categories/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/categories/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    categories is a list of categories to query.
+    Examples: all, managed, composite, claim

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/categories/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/categories/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    conditions is a list of conditions to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    A QueryCondition specifies how to query a condition.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/reason/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/reason/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    reason queries based on the reason field of the condition.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/status/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/status/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    status is the status of condition to query. This is either True, False
+    or Unknown.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/type/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/type/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    type is the type of condition to query.
+    Examples: Ready, Synced

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    creationTimestamp queries for objects with a range of creation times.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/after/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/after/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/before/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/before/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    groupKind is the GroupKinds of objects to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/apiGroup/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/apiGroup/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    apiGroup is the API group to query. If empty all groups will be queried.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/kind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/kind/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    kind is kind to query. Kinds are case-insensitive and also match plural
+    resources. If empty all kinds will be queried.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/id/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/id/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    id is the object ID to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/jsonpath/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/jsonpath/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    jsonpath is a JSONPath filter expression that will be applied to objects
+    as a filter. It must return a boolean; no objects will be matched if it
+    returns any other type. jsonpath should be used as a last resort; using
+    the other filter fields will generally be more efficient.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/labels/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/labels/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    labels are the labels of objects to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/name/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/name/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    name is the name of objects to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/namespace/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/filter/properties/objects/items/properties/namespace/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    namespace is the namespace WITHIN a control plane to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/freshness/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/freshness/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    freshness specifies resource versions per control plane to wait for before
+    returning results. It's helpful to ensure consistency for read-after-write.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/freshness/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/freshness/items/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    Freshness specifies a resource version per control plane to wait for before
+    returning results. It's helpful to ensure consistency for read-after-write.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/freshness/items/properties/controlPlane/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/freshness/items/properties/controlPlane/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    controlPlane is the name of the control plane to check for freshness of the data.
+    In case of Query, the name is defaulted and must match the control plane
+    name of the request.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/freshness/items/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/freshness/items/properties/group/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    group is the group of the control plane to check for freshness of
+    the data. In case of GroupQuery or Query, the group is defaulted and
+    must match the group of the request.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/freshness/items/properties/resourceVersion/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/freshness/items/properties/resourceVersion/description.yaml
@@ -1,0 +1,7 @@
+description: |-
+    resourceVersion is the resource version of the specified control plane
+    to wait for before executing the query. Normal request timeouts apply.
+    The resourceVersion is a large integer, returned by previous queries or
+    by requests against the control plane Kubernetes API.
+    
+    Note that resource versions between control planes are not correlated.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/limit/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/limit/description.yaml
@@ -1,7 +1,6 @@
 description: |-
     limit is the maximal number of objects to return. Defaulted to 100.
     
-    
     Note that a limit in a relation subsumes all the children of all parents,
     i.e. a small limit only makes sense if there is only a single parent,
     e.g. selected via spec.IDs.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/objects/properties/controlPlane/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/objects/properties/controlPlane/description.yaml
@@ -1,3 +1,3 @@
 description: |-
-    controlPlane specifies that the controlplane name and namespace of the
+    controlPlane specifies that the control plane name and namespace of the
     object should be returned.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/objects/properties/mutablePath/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/objects/properties/mutablePath/description.yaml
@@ -1,3 +1,3 @@
 description: |-
     mutablePath specifies whether to return the mutable path of the object,
-    i.e. the path to the object in the controlplane Kubernetes API.
+    i.e. the path to the object in the control plane Kubernetes API.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/objects/properties/relations/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/objects/properties/relations/description.yaml
@@ -3,6 +3,5 @@ description: |-
     Relation names are predefined strings relative to the release of
     Spaces.
     
-    
     Examples: owners, descendants, resources, events, or their transitive
     equivalents owners+, descendants+, resources+.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/objects/properties/table/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/objects/properties/table/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    table specifies whether to return the object in a table format.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/objects/properties/table/properties/grouping/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/objects/properties/table/properties/grouping/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    grouping specifies how to group the returned objects into multiple
+    tables where every table can have different sets of columns.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/order/items/properties/apiGroup/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/order/items/properties/apiGroup/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    APIGroup specifies how to order by API group.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/order/items/properties/cluster/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/order/items/properties/cluster/description.yaml
@@ -1,2 +1,2 @@
 description: |-
-    controlPlane specifies how to order by controlplane.
+    controlPlane specifies how to order by control plane name.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/order/items/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/order/items/properties/group/description.yaml
@@ -1,2 +1,2 @@
 description: |-
-    group specifies how to order by group.
+    group specifies how to order by control plane group.

--- a/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/page/properties/cursor/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/GroupQuery/properties/spec/properties/page/properties/cursor/description.yaml
@@ -4,5 +4,4 @@ description: |-
     response to a previous query. If neither first nor cursor is specified,
     objects are returned from the beginning.
     
-    
     Note that cursor values are not stable under different orderings.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/description.yaml
@@ -1,3 +1,3 @@
 description: |-
-    Query represents a query against one controlplane, the one with the same
+    Query represents a query against one control plane, the one with the same
     name and namespace as the query.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/objects/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/objects/description.yaml
@@ -1,2 +1,4 @@
 description: |-
     objects is the list of objects returned by the query.
+    
+    Objects is mutual exclusive with Tables.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/objects/items/properties/$errors/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/objects/items/properties/$errors/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    errors is the list of errors that occurred while processing the object.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/objects/items/properties/$errors/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/objects/items/properties/$errors/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    tables is the list of tables returned by the query. Objects are grouped
+    as specified in the query. Hence, potentially multiple tables are returned.
+    
+    Objects is mutual exclusive with Tables.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    QueryResponseTable is a table representation of a set of API resources.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    columns is the list of columns in the table.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    TableColumnDefinition contains information about a column returned in the Table.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/properties/description/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/properties/description/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    description is a human readable description of this column.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/properties/format/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/properties/format/description.yaml
@@ -1,0 +1,6 @@
+description: |-
+    format is an optional OpenAPI type modifier for this column. A format modifies the type and
+    imposes additional rules, like date or time formatting for a string. The 'name' format is applied
+    to the primary identifier column which has type 'string' to assist in clients identifying column
+    is the resource name.
+    See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/properties/name/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/properties/name/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    name is a human readable name for the column.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/properties/priority/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/properties/priority/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    priority is an integer defining the relative importance of this column compared to others. Lower
+    numbers are considered higher priority. Columns that may be omitted in limited space scenarios
+    should be given a higher priority.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/properties/type/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/columns/items/properties/type/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    type is an OpenAPI type definition for this column, such as number, integer, string, or
+    array.
+    See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/groupVersionKind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/groupVersionKind/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    groupVersionKind is the group, version, and kind of the objects in the table.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/groupVersionKind/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/groupVersionKind/properties/group/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/groupVersionKind/properties/kind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/groupVersionKind/properties/kind/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/groupVersionKind/properties/version/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/groupVersionKind/properties/version/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    rows is the list of rows in the table.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    TableRow is an individual row in a table.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/cells/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/cells/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    cells will be as wide as the column definitions array and may contain strings, numbers (float64 or
+    int64), booleans, simple maps, lists, or null. See the type field of the column definition for a
+    more detailed description.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/cells/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/cells/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    conditions describe additional status of a row that are relevant for a human user. These conditions
+    apply to the row, not to the object, and will be specific to table output. The only defined
+    condition type is 'Completed', for a row that indicates a resource that has run to completion and
+    can be given less visual priority.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    TableRowCondition allows a row to be marked with additional information.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/message/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/message/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    Human readable message indicating details about last transition.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/reason/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/reason/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    (brief) machine readable reason for the condition's last transition.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/status/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/status/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    Status of the condition, one of True, False, Unknown.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/type/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/type/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    Type of row condition. The only defined value is 'Completed' indicating that the
+    object this row represents has reached a completed state and may be given less visual
+    priority than other rows. Clients are not required to honor any conditions but should
+    be consistent where possible about handling the conditions.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/object/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/response/properties/tables/items/properties/rows/items/properties/object/description.yaml
@@ -1,0 +1,7 @@
+description: |-
+    This field contains the requested additional information about each object based on the includeObject
+    policy when requesting the Table. If 'None', this field is empty, if 'Object' this will be the
+    default serialization of the object for the current API version, and if 'Metadata' (the default) will
+    contain the object metadata. Check the returned kind and apiVersion of the object before parsing.
+    The media type of the object will always match the enclosing list - if this as a JSON table, these
+    will be JSON encoded objects.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/controlPlane/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/controlPlane/description.yaml
@@ -1,3 +1,3 @@
 description: |-
-    controlPlane specifies which controlplanes to query. If empty, all
-    controlplanes are queried in the given scope.
+    controlPlane specifies which control planes to query. If empty, all
+    control planes are queried in the given scope.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/controlPlane/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/controlPlane/properties/group/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    group is the group of the control plane to query. If empty, all groups
+    are queried in the given scope.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/controlPlane/properties/name/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/controlPlane/properties/name/description.yaml
@@ -1,3 +1,3 @@
 description: |-
-    name is the name of the controlplane to query. If empty, all controlplanes
+    name is the name of the control plane to query. If empty, all control planes
     are queried in the given scope.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    objects specifies what to filter. Objects in the query response will
+    match all criteria in at least one of the specified filters.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    QueryFilter specifies what to filter. Objects in the query response will
+    match all criteria specified in the filter.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/categories/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/categories/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    categories is a list of categories to query.
+    Examples: all, managed, composite, claim

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/categories/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/categories/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/conditions/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/conditions/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    conditions is a list of conditions to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    A QueryCondition specifies how to query a condition.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/reason/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/reason/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    reason queries based on the reason field of the condition.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/status/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/status/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    status is the status of condition to query. This is either True, False
+    or Unknown.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/type/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/type/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    type is the type of condition to query.
+    Examples: Ready, Synced

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    creationTimestamp queries for objects with a range of creation times.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/after/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/after/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/before/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/before/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/groupKind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/groupKind/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    groupKind is the GroupKinds of objects to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/apiGroup/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/apiGroup/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    apiGroup is the API group to query. If empty all groups will be queried.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/kind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/kind/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    kind is kind to query. Kinds are case-insensitive and also match plural
+    resources. If empty all kinds will be queried.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/id/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/id/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    id is the object ID to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/jsonpath/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/jsonpath/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    jsonpath is a JSONPath filter expression that will be applied to objects
+    as a filter. It must return a boolean; no objects will be matched if it
+    returns any other type. jsonpath should be used as a last resort; using
+    the other filter fields will generally be more efficient.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/labels/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/labels/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    labels are the labels of objects to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/name/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/name/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    name is the name of objects to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/namespace/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/filter/properties/objects/items/properties/namespace/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    namespace is the namespace WITHIN a control plane to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/freshness/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/freshness/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    freshness specifies resource versions per control plane to wait for before
+    returning results. It's helpful to ensure consistency for read-after-write.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/freshness/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/freshness/items/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    Freshness specifies a resource version per control plane to wait for before
+    returning results. It's helpful to ensure consistency for read-after-write.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/freshness/items/properties/controlPlane/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/freshness/items/properties/controlPlane/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    controlPlane is the name of the control plane to check for freshness of the data.
+    In case of Query, the name is defaulted and must match the control plane
+    name of the request.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/freshness/items/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/freshness/items/properties/group/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    group is the group of the control plane to check for freshness of
+    the data. In case of GroupQuery or Query, the group is defaulted and
+    must match the group of the request.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/freshness/items/properties/resourceVersion/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/freshness/items/properties/resourceVersion/description.yaml
@@ -1,0 +1,7 @@
+description: |-
+    resourceVersion is the resource version of the specified control plane
+    to wait for before executing the query. Normal request timeouts apply.
+    The resourceVersion is a large integer, returned by previous queries or
+    by requests against the control plane Kubernetes API.
+    
+    Note that resource versions between control planes are not correlated.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/limit/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/limit/description.yaml
@@ -1,7 +1,6 @@
 description: |-
     limit is the maximal number of objects to return. Defaulted to 100.
     
-    
     Note that a limit in a relation subsumes all the children of all parents,
     i.e. a small limit only makes sense if there is only a single parent,
     e.g. selected via spec.IDs.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/objects/properties/controlPlane/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/objects/properties/controlPlane/description.yaml
@@ -1,3 +1,3 @@
 description: |-
-    controlPlane specifies that the controlplane name and namespace of the
+    controlPlane specifies that the control plane name and namespace of the
     object should be returned.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/objects/properties/mutablePath/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/objects/properties/mutablePath/description.yaml
@@ -1,3 +1,3 @@
 description: |-
     mutablePath specifies whether to return the mutable path of the object,
-    i.e. the path to the object in the controlplane Kubernetes API.
+    i.e. the path to the object in the control plane Kubernetes API.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/objects/properties/relations/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/objects/properties/relations/description.yaml
@@ -3,6 +3,5 @@ description: |-
     Relation names are predefined strings relative to the release of
     Spaces.
     
-    
     Examples: owners, descendants, resources, events, or their transitive
     equivalents owners+, descendants+, resources+.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/objects/properties/table/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/objects/properties/table/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    table specifies whether to return the object in a table format.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/objects/properties/table/properties/grouping/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/objects/properties/table/properties/grouping/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    grouping specifies how to group the returned objects into multiple
+    tables where every table can have different sets of columns.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/order/items/properties/apiGroup/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/order/items/properties/apiGroup/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    APIGroup specifies how to order by API group.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/order/items/properties/cluster/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/order/items/properties/cluster/description.yaml
@@ -1,2 +1,2 @@
 description: |-
-    controlPlane specifies how to order by controlplane.
+    controlPlane specifies how to order by control plane name.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/order/items/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/order/items/properties/group/description.yaml
@@ -1,2 +1,2 @@
 description: |-
-    group specifies how to order by group.
+    group specifies how to order by control plane group.

--- a/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/page/properties/cursor/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/Query/properties/spec/properties/page/properties/cursor/description.yaml
@@ -4,5 +4,4 @@ description: |-
     response to a previous query. If neither first nor cursor is specified,
     objects are returned from the beginning.
     
-    
     Note that cursor values are not stable under different orderings.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/description.yaml
@@ -1,2 +1,2 @@
 description: |-
-    SpaceQuery represents a query against all controlplanes.
+    SpaceQuery represents a query against all control planes.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/objects/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/objects/description.yaml
@@ -1,2 +1,4 @@
 description: |-
     objects is the list of objects returned by the query.
+    
+    Objects is mutual exclusive with Tables.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/objects/items/properties/$errors/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/objects/items/properties/$errors/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    errors is the list of errors that occurred while processing the object.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/objects/items/properties/$errors/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/objects/items/properties/$errors/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    tables is the list of tables returned by the query. Objects are grouped
+    as specified in the query. Hence, potentially multiple tables are returned.
+    
+    Objects is mutual exclusive with Tables.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    QueryResponseTable is a table representation of a set of API resources.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    columns is the list of columns in the table.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    TableColumnDefinition contains information about a column returned in the Table.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/properties/description/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/properties/description/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    description is a human readable description of this column.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/properties/format/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/properties/format/description.yaml
@@ -1,0 +1,6 @@
+description: |-
+    format is an optional OpenAPI type modifier for this column. A format modifies the type and
+    imposes additional rules, like date or time formatting for a string. The 'name' format is applied
+    to the primary identifier column which has type 'string' to assist in clients identifying column
+    is the resource name.
+    See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/properties/name/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/properties/name/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    name is a human readable name for the column.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/properties/priority/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/properties/priority/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    priority is an integer defining the relative importance of this column compared to others. Lower
+    numbers are considered higher priority. Columns that may be omitted in limited space scenarios
+    should be given a higher priority.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/properties/type/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/columns/items/properties/type/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    type is an OpenAPI type definition for this column, such as number, integer, string, or
+    array.
+    See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/groupVersionKind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/groupVersionKind/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    groupVersionKind is the group, version, and kind of the objects in the table.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/group/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/kind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/kind/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/version/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/groupVersionKind/properties/version/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    rows is the list of rows in the table.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    TableRow is an individual row in a table.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/cells/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/cells/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    cells will be as wide as the column definitions array and may contain strings, numbers (float64 or
+    int64), booleans, simple maps, lists, or null. See the type field of the column definition for a
+    more detailed description.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/cells/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/cells/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    conditions describe additional status of a row that are relevant for a human user. These conditions
+    apply to the row, not to the object, and will be specific to table output. The only defined
+    condition type is 'Completed', for a row that indicates a resource that has run to completion and
+    can be given less visual priority.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    TableRowCondition allows a row to be marked with additional information.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/message/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/message/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    Human readable message indicating details about last transition.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/reason/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/reason/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    (brief) machine readable reason for the condition's last transition.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/status/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/status/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    Status of the condition, one of True, False, Unknown.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/type/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/conditions/items/properties/type/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    Type of row condition. The only defined value is 'Completed' indicating that the
+    object this row represents has reached a completed state and may be given less visual
+    priority than other rows. Clients are not required to honor any conditions but should
+    be consistent where possible about handling the conditions.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/object/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/response/properties/tables/items/properties/rows/items/properties/object/description.yaml
@@ -1,0 +1,7 @@
+description: |-
+    This field contains the requested additional information about each object based on the includeObject
+    policy when requesting the Table. If 'None', this field is empty, if 'Object' this will be the
+    default serialization of the object for the current API version, and if 'Metadata' (the default) will
+    contain the object metadata. Check the returned kind and apiVersion of the object before parsing.
+    The media type of the object will always match the enclosing list - if this as a JSON table, these
+    will be JSON encoded objects.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/controlPlane/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/controlPlane/description.yaml
@@ -1,3 +1,3 @@
 description: |-
-    controlPlane specifies which controlplanes to query. If empty, all
-    controlplanes are queried in the given scope.
+    controlPlane specifies which control planes to query. If empty, all
+    control planes are queried in the given scope.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/controlPlane/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/controlPlane/properties/group/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    group is the group of the control plane to query. If empty, all groups
+    are queried in the given scope.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/controlPlane/properties/name/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/controlPlane/properties/name/description.yaml
@@ -1,3 +1,3 @@
 description: |-
-    name is the name of the controlplane to query. If empty, all controlplanes
+    name is the name of the control plane to query. If empty, all control planes
     are queried in the given scope.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    objects specifies what to filter. Objects in the query response will
+    match all criteria in at least one of the specified filters.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    QueryFilter specifies what to filter. Objects in the query response will
+    match all criteria specified in the filter.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/categories/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/categories/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    categories is a list of categories to query.
+    Examples: all, managed, composite, claim

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/categories/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/categories/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    conditions is a list of conditions to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    A QueryCondition specifies how to query a condition.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/reason/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/reason/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    reason queries based on the reason field of the condition.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/status/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/status/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    status is the status of condition to query. This is either True, False
+    or Unknown.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/type/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/conditions/items/properties/type/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    type is the type of condition to query.
+    Examples: Ready, Synced

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    creationTimestamp queries for objects with a range of creation times.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/after/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/after/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/before/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/creationTimestamp/properties/before/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    groupKind is the GroupKinds of objects to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/apiGroup/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/apiGroup/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    apiGroup is the API group to query. If empty all groups will be queried.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/kind/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/groupKind/properties/kind/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    kind is kind to query. Kinds are case-insensitive and also match plural
+    resources. If empty all kinds will be queried.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/id/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/id/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    id is the object ID to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/jsonpath/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/jsonpath/description.yaml
@@ -1,0 +1,5 @@
+description: |-
+    jsonpath is a JSONPath filter expression that will be applied to objects
+    as a filter. It must return a boolean; no objects will be matched if it
+    returns any other type. jsonpath should be used as a last resort; using
+    the other filter fields will generally be more efficient.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/labels/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/labels/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    labels are the labels of objects to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/name/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/name/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    name is the name of objects to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/namespace/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/filter/properties/objects/items/properties/namespace/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    namespace is the namespace WITHIN a control plane to query.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/freshness/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/freshness/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    freshness specifies resource versions per control plane to wait for before
+    returning results. It's helpful to ensure consistency for read-after-write.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/freshness/items/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/freshness/items/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    Freshness specifies a resource version per control plane to wait for before
+    returning results. It's helpful to ensure consistency for read-after-write.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/freshness/items/properties/controlPlane/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/freshness/items/properties/controlPlane/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    controlPlane is the name of the control plane to check for freshness of the data.
+    In case of Query, the name is defaulted and must match the control plane
+    name of the request.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/freshness/items/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/freshness/items/properties/group/description.yaml
@@ -1,0 +1,4 @@
+description: |-
+    group is the group of the control plane to check for freshness of
+    the data. In case of GroupQuery or Query, the group is defaulted and
+    must match the group of the request.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/freshness/items/properties/resourceVersion/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/freshness/items/properties/resourceVersion/description.yaml
@@ -1,0 +1,7 @@
+description: |-
+    resourceVersion is the resource version of the specified control plane
+    to wait for before executing the query. Normal request timeouts apply.
+    The resourceVersion is a large integer, returned by previous queries or
+    by requests against the control plane Kubernetes API.
+    
+    Note that resource versions between control planes are not correlated.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/limit/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/limit/description.yaml
@@ -1,7 +1,6 @@
 description: |-
     limit is the maximal number of objects to return. Defaulted to 100.
     
-    
     Note that a limit in a relation subsumes all the children of all parents,
     i.e. a small limit only makes sense if there is only a single parent,
     e.g. selected via spec.IDs.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/objects/properties/controlPlane/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/objects/properties/controlPlane/description.yaml
@@ -1,3 +1,3 @@
 description: |-
-    controlPlane specifies that the controlplane name and namespace of the
+    controlPlane specifies that the control plane name and namespace of the
     object should be returned.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/objects/properties/mutablePath/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/objects/properties/mutablePath/description.yaml
@@ -1,3 +1,3 @@
 description: |-
     mutablePath specifies whether to return the mutable path of the object,
-    i.e. the path to the object in the controlplane Kubernetes API.
+    i.e. the path to the object in the control plane Kubernetes API.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/objects/properties/relations/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/objects/properties/relations/description.yaml
@@ -3,6 +3,5 @@ description: |-
     Relation names are predefined strings relative to the release of
     Spaces.
     
-    
     Examples: owners, descendants, resources, events, or their transitive
     equivalents owners+, descendants+, resources+.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/objects/properties/table/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/objects/properties/table/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    table specifies whether to return the object in a table format.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/objects/properties/table/properties/grouping/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/objects/properties/table/properties/grouping/description.yaml
@@ -1,0 +1,3 @@
+description: |-
+    grouping specifies how to group the returned objects into multiple
+    tables where every table can have different sets of columns.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/order/items/properties/apiGroup/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/order/items/properties/apiGroup/description.yaml
@@ -1,0 +1,2 @@
+description: |-
+    APIGroup specifies how to order by API group.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/order/items/properties/cluster/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/order/items/properties/cluster/description.yaml
@@ -1,2 +1,2 @@
 description: |-
-    controlPlane specifies how to order by controlplane.
+    controlPlane specifies how to order by control plane name.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/order/items/properties/group/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/order/items/properties/group/description.yaml
@@ -1,2 +1,2 @@
 description: |-
-    group specifies how to order by group.
+    group specifies how to order by control plane group.

--- a/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/page/properties/cursor/description.yaml
+++ b/content/all-spaces/query-api/spaces.upbound.io/SpaceQuery/properties/spec/properties/page/properties/cursor/description.yaml
@@ -4,5 +4,4 @@ description: |-
     response to a previous query. If neither first nor cursor is specified,
     objects are returned from the beginning.
     
-    
     Note that cursor values are not stable under different orderings.

--- a/content/all-spaces/query-api/yaml/spaces.upbound.io_groupqueries.yaml
+++ b/content/all-spaces/query-api/yaml/spaces.upbound.io_groupqueries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: groupqueries.spaces.upbound.io
 spec:
   group: spaces.upbound.io
@@ -14,10 +14,10 @@ spec:
     singular: groupquery
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: GroupQuery represents a query against a group of controlplanes.
+        description: GroupQuery represents a query against a group of control planes.
         properties:
           apiVersion:
             description: |-
@@ -77,7 +77,10 @@ spec:
                   is always true.
                 type: boolean
               objects:
-                description: objects is the list of objects returned by the query.
+                description: |-
+                  objects is the list of objects returned by the query.
+
+                  Objects is mutual exclusive with Tables.
                 items:
                   description: QueryResponseObject is one object returned by the query.
                   properties:
@@ -140,6 +143,139 @@ spec:
                       type: object
                   type: object
                 type: array
+              tables:
+                description: |-
+                  tables is the list of tables returned by the query. Objects are grouped
+                  as specified in the query. Hence, potentially multiple tables are returned.
+
+                  Objects is mutual exclusive with Tables.
+                items:
+                  description: QueryResponseTable is a table representation of a set
+                    of API resources.
+                  properties:
+                    columns:
+                      description: columns is the list of columns in the table.
+                      items:
+                        description: TableColumnDefinition contains information about
+                          a column returned in the Table.
+                        properties:
+                          description:
+                            description: description is a human readable description
+                              of this column.
+                            type: string
+                          format:
+                            description: |-
+                              format is an optional OpenAPI type modifier for this column. A format modifies the type and
+                              imposes additional rules, like date or time formatting for a string. The 'name' format is applied
+                              to the primary identifier column which has type 'string' to assist in clients identifying column
+                              is the resource name.
+                              See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+                            type: string
+                          name:
+                            description: name is a human readable name for the column.
+                            type: string
+                          priority:
+                            description: |-
+                              priority is an integer defining the relative importance of this column compared to others. Lower
+                              numbers are considered higher priority. Columns that may be omitted in limited space scenarios
+                              should be given a higher priority.
+                            format: int32
+                            type: integer
+                          type:
+                            description: |-
+                              type is an OpenAPI type definition for this column, such as number, integer, string, or
+                              array.
+                              See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+                            type: string
+                        required:
+                        - description
+                        - format
+                        - name
+                        - priority
+                        - type
+                        type: object
+                      type: array
+                    groupVersionKind:
+                      description: groupVersionKind is the group, version, and kind
+                        of the objects in the table.
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - version
+                      type: object
+                    rows:
+                      description: rows is the list of rows in the table.
+                      items:
+                        description: TableRow is an individual row in a table.
+                        properties:
+                          cells:
+                            description: |-
+                              cells will be as wide as the column definitions array and may contain strings, numbers (float64 or
+                              int64), booleans, simple maps, lists, or null. See the type field of the column definition for a
+                              more detailed description.
+                            items: {}
+                            type: array
+                          conditions:
+                            description: |-
+                              conditions describe additional status of a row that are relevant for a human user. These conditions
+                              apply to the row, not to the object, and will be specific to table output. The only defined
+                              condition type is 'Completed', for a row that indicates a resource that has run to completion and
+                              can be given less visual priority.
+                            items:
+                              description: TableRowCondition allows a row to be marked
+                                with additional information.
+                              properties:
+                                message:
+                                  description: Human readable message indicating details
+                                    about last transition.
+                                  type: string
+                                reason:
+                                  description: (brief) machine readable reason for
+                                    the condition's last transition.
+                                  type: string
+                                status:
+                                  description: Status of the condition, one of True,
+                                    False, Unknown.
+                                  type: string
+                                type:
+                                  description: |-
+                                    Type of row condition. The only defined value is 'Completed' indicating that the
+                                    object this row represents has reached a completed state and may be given less visual
+                                    priority than other rows. Clients are not required to honor any conditions but should
+                                    be consistent where possible about handling the conditions.
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          object:
+                            description: |-
+                              This field contains the requested additional information about each object based on the includeObject
+                              policy when requesting the Table. If "None", this field is empty, if "Object" this will be the
+                              default serialization of the object for the current API version, and if "Metadata" (the default) will
+                              contain the object metadata. Check the returned kind and apiVersion of the object before parsing.
+                              The media type of the object will always match the enclosing list - if this as a JSON table, these
+                              will be JSON encoded objects.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - cells
+                        type: object
+                      type: array
+                  required:
+                  - columns
+                  - groupVersionKind
+                  - rows
+                  type: object
+                type: array
               warnings:
                 description: |-
                   warnings is a list of warnings that occurred while processing the query.
@@ -167,114 +303,158 @@ spec:
               filter:
                 description: filter specifies how to filter the returned objects.
                 properties:
-                  categories:
-                    description: |-
-                      categories is a list of categories to query. If empty, all categories are
-                      queried in the given scope.
-                      Examples: all, managed, composite, claim
-                    items:
-                      type: string
-                    type: array
-                  conditions:
-                    description: |-
-                      conditions is a list of conditions to query. If empty, all conditions are
-                      queried in the given scope.
-                    items:
-                      description: A QueryCondition specifies how to query a condition.
-                      properties:
-                        status:
-                          description: |-
-                            status is the status of condition to query. This is either True, False
-                            or Unknown.
-                          type: string
-                        type:
-                          description: |-
-                            type is the type of condition to query.
-                            Examples: Ready, Synced
-                          type: string
-                      required:
-                      - status
-                      - type
-                      type: object
-                    type: array
                   controlPlane:
                     description: |-
-                      controlPlane specifies which controlplanes to query. If empty, all
-                      controlplanes are queried in the given scope.
+                      controlPlane specifies which control planes to query. If empty, all
+                      control planes are queried in the given scope.
                     properties:
-                      name:
+                      group:
                         description: |-
-                          name is the name of the controlplane to query. If empty, all controlplanes
+                          group is the group of the control plane to query. If empty, all groups
                           are queried in the given scope.
                         type: string
-                      namespace:
+                      name:
                         description: |-
-                          namespace is the namespace of the controlplane to query. If empty, all
-                          namespaces are queried in the given scope.
+                          name is the name of the control plane to query. If empty, all control planes
+                          are queried in the given scope.
                         type: string
                     type: object
-                  group:
+                  objects:
                     description: |-
-                      group is the API group to query. If empty, all groups are queried in the
-                      given scope.
-                    type: string
-                  ids:
-                    description: "\t# ids: [\"id1\",\"id2\"] # to get objects explicitly
-                      by id."
+                      objects specifies what to filter. Objects in the query response will
+                      match all criteria in at least one of the specified filters.
                     items:
-                      type: string
-                    type: array
-                  kind:
-                    description: |-
-                      kind is the API kind to query. If empty, all kinds are queried in the
-                      given scope. The kind is case-insensitive. The kind also matches plural
-                      resources.
-                    type: string
-                  name:
-                    description: |-
-                      name is the name of the object to query. If empty, all objects are queried
-                      in the given scope.
-                    type: string
-                  namespace:
-                    description: |-
-                      namespace is the namespace WITHIN a controlplane to query. If empty,
-                      all namespaces are queried in the given scope.
-                    type: string
-                  owners:
-                    description: |-
-                      owners is a list of owners to query. An object matches if it has at least
-                      one owner in the list.
-                    items:
-                      description: A QueryOwner specifies how to query by owner.
+                      description: |-
+                        QueryFilter specifies what to filter. Objects in the query response will
+                        match all criteria specified in the filter.
                       properties:
-                        group:
-                          description: name is the name of the owner to match.
+                        categories:
+                          description: |-
+                            categories is a list of categories to query.
+                            Examples: all, managed, composite, claim
+                          items:
+                            type: string
+                          type: array
+                        conditions:
+                          description: conditions is a list of conditions to query.
+                          items:
+                            description: A QueryCondition specifies how to query a
+                              condition.
+                            properties:
+                              reason:
+                                description: reason queries based on the reason field
+                                  of the condition.
+                                type: string
+                              status:
+                                description: |-
+                                  status is the status of condition to query. This is either True, False
+                                  or Unknown.
+                                type: string
+                              type:
+                                description: |-
+                                  type is the type of condition to query.
+                                  Examples: Ready, Synced
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          type: array
+                        creationTimestamp:
+                          description: creationTimestamp queries for objects with
+                            a range of creation times.
+                          properties:
+                            after:
+                              format: date-time
+                              type: string
+                            before:
+                              format: date-time
+                              type: string
+                          type: object
+                        groupKind:
+                          description: groupKind is the GroupKinds of objects to query.
+                          properties:
+                            apiGroup:
+                              description: apiGroup is the API group to query. If
+                                empty all groups will be queried.
+                              type: string
+                            kind:
+                              description: |-
+                                kind is kind to query. Kinds are case-insensitive and also match plural
+                                resources. If empty all kinds will be queried.
+                              type: string
+                          type: object
+                        id:
+                          description: id is the object ID to query.
                           type: string
-                        kind:
-                          description: kind is the kind of the owner to match.
+                        jsonpath:
+                          description: |-
+                            jsonpath is a JSONPath filter expression that will be applied to objects
+                            as a filter. It must return a boolean; no objects will be matched if it
+                            returns any other type. jsonpath should be used as a last resort; using
+                            the other filter fields will generally be more efficient.
                           type: string
-                        uid:
-                          description: uid is the uid of the owner to match.
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: labels are the labels of objects to query.
+                          type: object
+                        name:
+                          description: name is the name of objects to query.
+                          type: string
+                        namespace:
+                          description: namespace is the namespace WITHIN a control
+                            plane to query.
                           type: string
                       type: object
                     type: array
-                  sql:
-                    description: |-
-                      sql is a SQL query to query. If empty, all objects are queried in the
-                      given scope.
-
-
-                      The current object can be referenced by the alias "o".
-
-
-                      WARNING: The where clause is highly dependent on the database
-                      schema and might change at any time. The schema is not documented.
-                    type: string
+                required:
+                - objects
                 type: object
+              freshness:
+                description: |-
+                  freshness specifies resource versions per control plane to wait for before
+                  returning results. It's helpful to ensure consistency for read-after-write.
+                items:
+                  description: |-
+                    Freshness specifies a resource version per control plane to wait for before
+                    returning results. It's helpful to ensure consistency for read-after-write.
+                  properties:
+                    controlPlane:
+                      description: |-
+                        controlPlane is the name of the control plane to check for freshness of the data.
+                        In case of Query, the name is defaulted and must match the control plane
+                        name of the request.
+                      type: string
+                    group:
+                      description: |-
+                        group is the group of the control plane to check for freshness of
+                        the data. In case of GroupQuery or Query, the group is defaulted and
+                        must match the group of the request.
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        resourceVersion is the resource version of the specified control plane
+                        to wait for before executing the query. Normal request timeouts apply.
+                        The resourceVersion is a large integer, returned by previous queries or
+                        by requests against the control plane Kubernetes API.
+
+                        Note that resource versions between control planes are not correlated.
+                      minLength: 1
+                      pattern: ^[0-9]+$
+                      type: string
+                  required:
+                  - controlPlane
+                  - group
+                  - resourceVersion
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - controlPlane
+                x-kubernetes-list-type: map
               limit:
                 description: |-
                   limit is the maximal number of objects to return. Defaulted to 100.
-
 
                   Note that a limit in a relation subsumes all the children of all parents,
                   i.e. a small limit only makes sense if there is only a single parent,
@@ -285,7 +465,7 @@ spec:
                 properties:
                   controlPlane:
                     description: |-
-                      controlPlane specifies that the controlplane name and namespace of the
+                      controlPlane specifies that the control plane name and namespace of the
                       object should be returned.
                     type: boolean
                   id:
@@ -298,7 +478,7 @@ spec:
                   mutablePath:
                     description: |-
                       mutablePath specifies whether to return the mutable path of the object,
-                      i.e. the path to the object in the controlplane Kubernetes API.
+                      i.e. the path to the object in the control plane Kubernetes API.
                     type: boolean
                   object:
                     description: |-
@@ -313,105 +493,113 @@ spec:
                       description: A QueryRelation specifies how to return objects
                         in a relation.
                       properties:
-                        filter:
-                          description: filter specifies how to filter the returned
+                        filters:
+                          description: filters specifies how to filter the returned
                             objects.
-                          properties:
-                            categories:
-                              description: |-
-                                categories is a list of categories to query. If empty, all categories are
-                                queried in the given scope.
-                                Examples: all, managed, composite, claim
-                              items:
-                                type: string
-                              type: array
-                            conditions:
-                              description: |-
-                                conditions is a list of conditions to query. If empty, all conditions are
-                                queried in the given scope.
-                              items:
-                                description: A QueryCondition specifies how to query
-                                  a condition.
+                          items:
+                            description: |-
+                              QueryFilter specifies what to filter. Objects in the query response will
+                              match all criteria specified in the filter.
+                            properties:
+                              categories:
+                                description: |-
+                                  categories is a list of categories to query.
+                                  Examples: all, managed, composite, claim
+                                items:
+                                  type: string
+                                type: array
+                              conditions:
+                                description: conditions is a list of conditions to
+                                  query.
+                                items:
+                                  description: A QueryCondition specifies how to query
+                                    a condition.
+                                  properties:
+                                    reason:
+                                      description: reason queries based on the reason
+                                        field of the condition.
+                                      type: string
+                                    status:
+                                      description: |-
+                                        status is the status of condition to query. This is either True, False
+                                        or Unknown.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type is the type of condition to query.
+                                        Examples: Ready, Synced
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                type: array
+                              creationTimestamp:
+                                description: creationTimestamp queries for objects
+                                  with a range of creation times.
                                 properties:
-                                  status:
-                                    description: |-
-                                      status is the status of condition to query. This is either True, False
-                                      or Unknown.
+                                  after:
+                                    format: date-time
                                     type: string
-                                  type:
-                                    description: |-
-                                      type is the type of condition to query.
-                                      Examples: Ready, Synced
+                                  before:
+                                    format: date-time
                                     type: string
-                                required:
-                                - status
-                                - type
                                 type: object
-                              type: array
-                            group:
-                              description: |-
-                                group is the API group to query. If empty, all groups are queried in the
-                                given scope.
-                              type: string
-                            kind:
-                              description: |-
-                                kind is the API kind to query. If empty, all kinds are queried in the
-                                given scope. The kind is case-insensitive. The kind also matches plural
-                                resources.
-                              type: string
-                            name:
-                              description: |-
-                                name is the name of the object to query. If empty, all objects are queried
-                                in the given scope.
-                              type: string
-                            namespace:
-                              description: |-
-                                namespace is the namespace WITHIN a controlplane to query. If empty,
-                                all namespaces are queried in the given scope.
-                              type: string
-                            owners:
-                              description: |-
-                                owners is a list of owners to query. An object matches if it has at least
-                                one owner in the list.
-                              items:
-                                description: A QueryOwner specifies how to query by
-                                  owner.
+                              groupKind:
+                                description: groupKind is the GroupKinds of objects
+                                  to query.
                                 properties:
-                                  group:
-                                    description: name is the name of the owner to
-                                      match.
+                                  apiGroup:
+                                    description: apiGroup is the API group to query.
+                                      If empty all groups will be queried.
                                     type: string
                                   kind:
-                                    description: kind is the kind of the owner to
-                                      match.
-                                    type: string
-                                  uid:
-                                    description: uid is the uid of the owner to match.
+                                    description: |-
+                                      kind is kind to query. Kinds are case-insensitive and also match plural
+                                      resources. If empty all kinds will be queried.
                                     type: string
                                 type: object
-                              type: array
-                            sql:
-                              description: |-
-                                sql is a SQL query to query. If empty, all objects are queried in the
-                                given scope.
-
-
-                                The current object can be referenced by the alias "o".
-
-
-                                WARNING: The where clause is highly dependent on the database
-                                schema and might change at any time. The schema is not documented.
-                              type: string
-                          type: object
+                              id:
+                                description: id is the object ID to query.
+                                type: string
+                              jsonpath:
+                                description: |-
+                                  jsonpath is a JSONPath filter expression that will be applied to objects
+                                  as a filter. It must return a boolean; no objects will be matched if it
+                                  returns any other type. jsonpath should be used as a last resort; using
+                                  the other filter fields will generally be more efficient.
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: labels are the labels of objects to query.
+                                type: object
+                              name:
+                                description: name is the name of objects to query.
+                                type: string
+                              namespace:
+                                description: namespace is the namespace WITHIN a control
+                                  plane to query.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     description: |-
                       relations specifies which relations to query and what to return.
                       Relation names are predefined strings relative to the release of
                       Spaces.
 
-
                       Examples: owners, descendants, resources, events, or their transitive
                       equivalents owners+, descendants+, resources+.
+                    type: object
+                  table:
+                    description: table specifies whether to return the object in a
+                      table format.
+                    properties:
+                      grouping:
+                        description: |-
+                          grouping specifies how to group the returned objects into multiple
+                          tables where every table can have different sets of columns.
+                        type: string
                     type: object
                 type: object
               order:
@@ -423,8 +611,15 @@ spec:
                   description: A QueryOrder specifies how to order. Exactly one of
                     the fields must be set.
                   properties:
+                    apiGroup:
+                      description: APIGroup specifies how to order by API group.
+                      enum:
+                      - Asc
+                      - Desc
+                      type: string
                     cluster:
-                      description: controlPlane specifies how to order by controlplane.
+                      description: controlPlane specifies how to order by control
+                        plane name.
                       type: string
                     creationTimestamp:
                       description: creationTimestamp specifies how to order by creation
@@ -434,7 +629,7 @@ spec:
                       - Desc
                       type: string
                     group:
-                      description: group specifies how to order by group.
+                      description: group specifies how to order by control plane group.
                       enum:
                       - Asc
                       - Desc
@@ -470,7 +665,6 @@ spec:
                       the format cannot be relied on. It is returned by the server in the
                       response to a previous query. If neither first nor cursor is specified,
                       objects are returned from the beginning.
-
 
                       Note that cursor values are not stable under different orderings.
                     type: string

--- a/content/all-spaces/query-api/yaml/spaces.upbound.io_queries.yaml
+++ b/content/all-spaces/query-api/yaml/spaces.upbound.io_queries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: queries.spaces.upbound.io
 spec:
   group: spaces.upbound.io
@@ -14,11 +14,11 @@ spec:
     singular: query
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - name: v1alpha2
     schema:
       openAPIV3Schema:
         description: |-
-          Query represents a query against one controlplane, the one with the same
+          Query represents a query against one control plane, the one with the same
           name and namespace as the query.
         properties:
           apiVersion:
@@ -79,7 +79,10 @@ spec:
                   is always true.
                 type: boolean
               objects:
-                description: objects is the list of objects returned by the query.
+                description: |-
+                  objects is the list of objects returned by the query.
+
+                  Objects is mutual exclusive with Tables.
                 items:
                   description: QueryResponseObject is one object returned by the query.
                   properties:
@@ -142,6 +145,139 @@ spec:
                       type: object
                   type: object
                 type: array
+              tables:
+                description: |-
+                  tables is the list of tables returned by the query. Objects are grouped
+                  as specified in the query. Hence, potentially multiple tables are returned.
+
+                  Objects is mutual exclusive with Tables.
+                items:
+                  description: QueryResponseTable is a table representation of a set
+                    of API resources.
+                  properties:
+                    columns:
+                      description: columns is the list of columns in the table.
+                      items:
+                        description: TableColumnDefinition contains information about
+                          a column returned in the Table.
+                        properties:
+                          description:
+                            description: description is a human readable description
+                              of this column.
+                            type: string
+                          format:
+                            description: |-
+                              format is an optional OpenAPI type modifier for this column. A format modifies the type and
+                              imposes additional rules, like date or time formatting for a string. The 'name' format is applied
+                              to the primary identifier column which has type 'string' to assist in clients identifying column
+                              is the resource name.
+                              See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+                            type: string
+                          name:
+                            description: name is a human readable name for the column.
+                            type: string
+                          priority:
+                            description: |-
+                              priority is an integer defining the relative importance of this column compared to others. Lower
+                              numbers are considered higher priority. Columns that may be omitted in limited space scenarios
+                              should be given a higher priority.
+                            format: int32
+                            type: integer
+                          type:
+                            description: |-
+                              type is an OpenAPI type definition for this column, such as number, integer, string, or
+                              array.
+                              See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+                            type: string
+                        required:
+                        - description
+                        - format
+                        - name
+                        - priority
+                        - type
+                        type: object
+                      type: array
+                    groupVersionKind:
+                      description: groupVersionKind is the group, version, and kind
+                        of the objects in the table.
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - version
+                      type: object
+                    rows:
+                      description: rows is the list of rows in the table.
+                      items:
+                        description: TableRow is an individual row in a table.
+                        properties:
+                          cells:
+                            description: |-
+                              cells will be as wide as the column definitions array and may contain strings, numbers (float64 or
+                              int64), booleans, simple maps, lists, or null. See the type field of the column definition for a
+                              more detailed description.
+                            items: {}
+                            type: array
+                          conditions:
+                            description: |-
+                              conditions describe additional status of a row that are relevant for a human user. These conditions
+                              apply to the row, not to the object, and will be specific to table output. The only defined
+                              condition type is 'Completed', for a row that indicates a resource that has run to completion and
+                              can be given less visual priority.
+                            items:
+                              description: TableRowCondition allows a row to be marked
+                                with additional information.
+                              properties:
+                                message:
+                                  description: Human readable message indicating details
+                                    about last transition.
+                                  type: string
+                                reason:
+                                  description: (brief) machine readable reason for
+                                    the condition's last transition.
+                                  type: string
+                                status:
+                                  description: Status of the condition, one of True,
+                                    False, Unknown.
+                                  type: string
+                                type:
+                                  description: |-
+                                    Type of row condition. The only defined value is 'Completed' indicating that the
+                                    object this row represents has reached a completed state and may be given less visual
+                                    priority than other rows. Clients are not required to honor any conditions but should
+                                    be consistent where possible about handling the conditions.
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          object:
+                            description: |-
+                              This field contains the requested additional information about each object based on the includeObject
+                              policy when requesting the Table. If "None", this field is empty, if "Object" this will be the
+                              default serialization of the object for the current API version, and if "Metadata" (the default) will
+                              contain the object metadata. Check the returned kind and apiVersion of the object before parsing.
+                              The media type of the object will always match the enclosing list - if this as a JSON table, these
+                              will be JSON encoded objects.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - cells
+                        type: object
+                      type: array
+                  required:
+                  - columns
+                  - groupVersionKind
+                  - rows
+                  type: object
+                type: array
               warnings:
                 description: |-
                   warnings is a list of warnings that occurred while processing the query.
@@ -169,114 +305,158 @@ spec:
               filter:
                 description: filter specifies how to filter the returned objects.
                 properties:
-                  categories:
-                    description: |-
-                      categories is a list of categories to query. If empty, all categories are
-                      queried in the given scope.
-                      Examples: all, managed, composite, claim
-                    items:
-                      type: string
-                    type: array
-                  conditions:
-                    description: |-
-                      conditions is a list of conditions to query. If empty, all conditions are
-                      queried in the given scope.
-                    items:
-                      description: A QueryCondition specifies how to query a condition.
-                      properties:
-                        status:
-                          description: |-
-                            status is the status of condition to query. This is either True, False
-                            or Unknown.
-                          type: string
-                        type:
-                          description: |-
-                            type is the type of condition to query.
-                            Examples: Ready, Synced
-                          type: string
-                      required:
-                      - status
-                      - type
-                      type: object
-                    type: array
                   controlPlane:
                     description: |-
-                      controlPlane specifies which controlplanes to query. If empty, all
-                      controlplanes are queried in the given scope.
+                      controlPlane specifies which control planes to query. If empty, all
+                      control planes are queried in the given scope.
                     properties:
-                      name:
+                      group:
                         description: |-
-                          name is the name of the controlplane to query. If empty, all controlplanes
+                          group is the group of the control plane to query. If empty, all groups
                           are queried in the given scope.
                         type: string
-                      namespace:
+                      name:
                         description: |-
-                          namespace is the namespace of the controlplane to query. If empty, all
-                          namespaces are queried in the given scope.
+                          name is the name of the control plane to query. If empty, all control planes
+                          are queried in the given scope.
                         type: string
                     type: object
-                  group:
+                  objects:
                     description: |-
-                      group is the API group to query. If empty, all groups are queried in the
-                      given scope.
-                    type: string
-                  ids:
-                    description: "\t# ids: [\"id1\",\"id2\"] # to get objects explicitly
-                      by id."
+                      objects specifies what to filter. Objects in the query response will
+                      match all criteria in at least one of the specified filters.
                     items:
-                      type: string
-                    type: array
-                  kind:
-                    description: |-
-                      kind is the API kind to query. If empty, all kinds are queried in the
-                      given scope. The kind is case-insensitive. The kind also matches plural
-                      resources.
-                    type: string
-                  name:
-                    description: |-
-                      name is the name of the object to query. If empty, all objects are queried
-                      in the given scope.
-                    type: string
-                  namespace:
-                    description: |-
-                      namespace is the namespace WITHIN a controlplane to query. If empty,
-                      all namespaces are queried in the given scope.
-                    type: string
-                  owners:
-                    description: |-
-                      owners is a list of owners to query. An object matches if it has at least
-                      one owner in the list.
-                    items:
-                      description: A QueryOwner specifies how to query by owner.
+                      description: |-
+                        QueryFilter specifies what to filter. Objects in the query response will
+                        match all criteria specified in the filter.
                       properties:
-                        group:
-                          description: name is the name of the owner to match.
+                        categories:
+                          description: |-
+                            categories is a list of categories to query.
+                            Examples: all, managed, composite, claim
+                          items:
+                            type: string
+                          type: array
+                        conditions:
+                          description: conditions is a list of conditions to query.
+                          items:
+                            description: A QueryCondition specifies how to query a
+                              condition.
+                            properties:
+                              reason:
+                                description: reason queries based on the reason field
+                                  of the condition.
+                                type: string
+                              status:
+                                description: |-
+                                  status is the status of condition to query. This is either True, False
+                                  or Unknown.
+                                type: string
+                              type:
+                                description: |-
+                                  type is the type of condition to query.
+                                  Examples: Ready, Synced
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          type: array
+                        creationTimestamp:
+                          description: creationTimestamp queries for objects with
+                            a range of creation times.
+                          properties:
+                            after:
+                              format: date-time
+                              type: string
+                            before:
+                              format: date-time
+                              type: string
+                          type: object
+                        groupKind:
+                          description: groupKind is the GroupKinds of objects to query.
+                          properties:
+                            apiGroup:
+                              description: apiGroup is the API group to query. If
+                                empty all groups will be queried.
+                              type: string
+                            kind:
+                              description: |-
+                                kind is kind to query. Kinds are case-insensitive and also match plural
+                                resources. If empty all kinds will be queried.
+                              type: string
+                          type: object
+                        id:
+                          description: id is the object ID to query.
                           type: string
-                        kind:
-                          description: kind is the kind of the owner to match.
+                        jsonpath:
+                          description: |-
+                            jsonpath is a JSONPath filter expression that will be applied to objects
+                            as a filter. It must return a boolean; no objects will be matched if it
+                            returns any other type. jsonpath should be used as a last resort; using
+                            the other filter fields will generally be more efficient.
                           type: string
-                        uid:
-                          description: uid is the uid of the owner to match.
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: labels are the labels of objects to query.
+                          type: object
+                        name:
+                          description: name is the name of objects to query.
+                          type: string
+                        namespace:
+                          description: namespace is the namespace WITHIN a control
+                            plane to query.
                           type: string
                       type: object
                     type: array
-                  sql:
-                    description: |-
-                      sql is a SQL query to query. If empty, all objects are queried in the
-                      given scope.
-
-
-                      The current object can be referenced by the alias "o".
-
-
-                      WARNING: The where clause is highly dependent on the database
-                      schema and might change at any time. The schema is not documented.
-                    type: string
+                required:
+                - objects
                 type: object
+              freshness:
+                description: |-
+                  freshness specifies resource versions per control plane to wait for before
+                  returning results. It's helpful to ensure consistency for read-after-write.
+                items:
+                  description: |-
+                    Freshness specifies a resource version per control plane to wait for before
+                    returning results. It's helpful to ensure consistency for read-after-write.
+                  properties:
+                    controlPlane:
+                      description: |-
+                        controlPlane is the name of the control plane to check for freshness of the data.
+                        In case of Query, the name is defaulted and must match the control plane
+                        name of the request.
+                      type: string
+                    group:
+                      description: |-
+                        group is the group of the control plane to check for freshness of
+                        the data. In case of GroupQuery or Query, the group is defaulted and
+                        must match the group of the request.
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        resourceVersion is the resource version of the specified control plane
+                        to wait for before executing the query. Normal request timeouts apply.
+                        The resourceVersion is a large integer, returned by previous queries or
+                        by requests against the control plane Kubernetes API.
+
+                        Note that resource versions between control planes are not correlated.
+                      minLength: 1
+                      pattern: ^[0-9]+$
+                      type: string
+                  required:
+                  - controlPlane
+                  - group
+                  - resourceVersion
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - controlPlane
+                x-kubernetes-list-type: map
               limit:
                 description: |-
                   limit is the maximal number of objects to return. Defaulted to 100.
-
 
                   Note that a limit in a relation subsumes all the children of all parents,
                   i.e. a small limit only makes sense if there is only a single parent,
@@ -287,7 +467,7 @@ spec:
                 properties:
                   controlPlane:
                     description: |-
-                      controlPlane specifies that the controlplane name and namespace of the
+                      controlPlane specifies that the control plane name and namespace of the
                       object should be returned.
                     type: boolean
                   id:
@@ -300,7 +480,7 @@ spec:
                   mutablePath:
                     description: |-
                       mutablePath specifies whether to return the mutable path of the object,
-                      i.e. the path to the object in the controlplane Kubernetes API.
+                      i.e. the path to the object in the control plane Kubernetes API.
                     type: boolean
                   object:
                     description: |-
@@ -315,105 +495,113 @@ spec:
                       description: A QueryRelation specifies how to return objects
                         in a relation.
                       properties:
-                        filter:
-                          description: filter specifies how to filter the returned
+                        filters:
+                          description: filters specifies how to filter the returned
                             objects.
-                          properties:
-                            categories:
-                              description: |-
-                                categories is a list of categories to query. If empty, all categories are
-                                queried in the given scope.
-                                Examples: all, managed, composite, claim
-                              items:
-                                type: string
-                              type: array
-                            conditions:
-                              description: |-
-                                conditions is a list of conditions to query. If empty, all conditions are
-                                queried in the given scope.
-                              items:
-                                description: A QueryCondition specifies how to query
-                                  a condition.
+                          items:
+                            description: |-
+                              QueryFilter specifies what to filter. Objects in the query response will
+                              match all criteria specified in the filter.
+                            properties:
+                              categories:
+                                description: |-
+                                  categories is a list of categories to query.
+                                  Examples: all, managed, composite, claim
+                                items:
+                                  type: string
+                                type: array
+                              conditions:
+                                description: conditions is a list of conditions to
+                                  query.
+                                items:
+                                  description: A QueryCondition specifies how to query
+                                    a condition.
+                                  properties:
+                                    reason:
+                                      description: reason queries based on the reason
+                                        field of the condition.
+                                      type: string
+                                    status:
+                                      description: |-
+                                        status is the status of condition to query. This is either True, False
+                                        or Unknown.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type is the type of condition to query.
+                                        Examples: Ready, Synced
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                type: array
+                              creationTimestamp:
+                                description: creationTimestamp queries for objects
+                                  with a range of creation times.
                                 properties:
-                                  status:
-                                    description: |-
-                                      status is the status of condition to query. This is either True, False
-                                      or Unknown.
+                                  after:
+                                    format: date-time
                                     type: string
-                                  type:
-                                    description: |-
-                                      type is the type of condition to query.
-                                      Examples: Ready, Synced
+                                  before:
+                                    format: date-time
                                     type: string
-                                required:
-                                - status
-                                - type
                                 type: object
-                              type: array
-                            group:
-                              description: |-
-                                group is the API group to query. If empty, all groups are queried in the
-                                given scope.
-                              type: string
-                            kind:
-                              description: |-
-                                kind is the API kind to query. If empty, all kinds are queried in the
-                                given scope. The kind is case-insensitive. The kind also matches plural
-                                resources.
-                              type: string
-                            name:
-                              description: |-
-                                name is the name of the object to query. If empty, all objects are queried
-                                in the given scope.
-                              type: string
-                            namespace:
-                              description: |-
-                                namespace is the namespace WITHIN a controlplane to query. If empty,
-                                all namespaces are queried in the given scope.
-                              type: string
-                            owners:
-                              description: |-
-                                owners is a list of owners to query. An object matches if it has at least
-                                one owner in the list.
-                              items:
-                                description: A QueryOwner specifies how to query by
-                                  owner.
+                              groupKind:
+                                description: groupKind is the GroupKinds of objects
+                                  to query.
                                 properties:
-                                  group:
-                                    description: name is the name of the owner to
-                                      match.
+                                  apiGroup:
+                                    description: apiGroup is the API group to query.
+                                      If empty all groups will be queried.
                                     type: string
                                   kind:
-                                    description: kind is the kind of the owner to
-                                      match.
-                                    type: string
-                                  uid:
-                                    description: uid is the uid of the owner to match.
+                                    description: |-
+                                      kind is kind to query. Kinds are case-insensitive and also match plural
+                                      resources. If empty all kinds will be queried.
                                     type: string
                                 type: object
-                              type: array
-                            sql:
-                              description: |-
-                                sql is a SQL query to query. If empty, all objects are queried in the
-                                given scope.
-
-
-                                The current object can be referenced by the alias "o".
-
-
-                                WARNING: The where clause is highly dependent on the database
-                                schema and might change at any time. The schema is not documented.
-                              type: string
-                          type: object
+                              id:
+                                description: id is the object ID to query.
+                                type: string
+                              jsonpath:
+                                description: |-
+                                  jsonpath is a JSONPath filter expression that will be applied to objects
+                                  as a filter. It must return a boolean; no objects will be matched if it
+                                  returns any other type. jsonpath should be used as a last resort; using
+                                  the other filter fields will generally be more efficient.
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: labels are the labels of objects to query.
+                                type: object
+                              name:
+                                description: name is the name of objects to query.
+                                type: string
+                              namespace:
+                                description: namespace is the namespace WITHIN a control
+                                  plane to query.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     description: |-
                       relations specifies which relations to query and what to return.
                       Relation names are predefined strings relative to the release of
                       Spaces.
 
-
                       Examples: owners, descendants, resources, events, or their transitive
                       equivalents owners+, descendants+, resources+.
+                    type: object
+                  table:
+                    description: table specifies whether to return the object in a
+                      table format.
+                    properties:
+                      grouping:
+                        description: |-
+                          grouping specifies how to group the returned objects into multiple
+                          tables where every table can have different sets of columns.
+                        type: string
                     type: object
                 type: object
               order:
@@ -425,8 +613,15 @@ spec:
                   description: A QueryOrder specifies how to order. Exactly one of
                     the fields must be set.
                   properties:
+                    apiGroup:
+                      description: APIGroup specifies how to order by API group.
+                      enum:
+                      - Asc
+                      - Desc
+                      type: string
                     cluster:
-                      description: controlPlane specifies how to order by controlplane.
+                      description: controlPlane specifies how to order by control
+                        plane name.
                       type: string
                     creationTimestamp:
                       description: creationTimestamp specifies how to order by creation
@@ -436,7 +631,7 @@ spec:
                       - Desc
                       type: string
                     group:
-                      description: group specifies how to order by group.
+                      description: group specifies how to order by control plane group.
                       enum:
                       - Asc
                       - Desc
@@ -472,7 +667,6 @@ spec:
                       the format cannot be relied on. It is returned by the server in the
                       response to a previous query. If neither first nor cursor is specified,
                       objects are returned from the beginning.
-
 
                       Note that cursor values are not stable under different orderings.
                     type: string

--- a/content/all-spaces/query-api/yaml/spaces.upbound.io_spacequeries.yaml
+++ b/content/all-spaces/query-api/yaml/spaces.upbound.io_spacequeries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.1
   name: spacequeries.spaces.upbound.io
 spec:
   group: spaces.upbound.io
@@ -14,10 +14,10 @@ spec:
     singular: spacequery
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: SpaceQuery represents a query against all controlplanes.
+        description: SpaceQuery represents a query against all control planes.
         properties:
           apiVersion:
             description: |-
@@ -77,7 +77,10 @@ spec:
                   is always true.
                 type: boolean
               objects:
-                description: objects is the list of objects returned by the query.
+                description: |-
+                  objects is the list of objects returned by the query.
+
+                  Objects is mutual exclusive with Tables.
                 items:
                   description: QueryResponseObject is one object returned by the query.
                   properties:
@@ -140,6 +143,139 @@ spec:
                       type: object
                   type: object
                 type: array
+              tables:
+                description: |-
+                  tables is the list of tables returned by the query. Objects are grouped
+                  as specified in the query. Hence, potentially multiple tables are returned.
+
+                  Objects is mutual exclusive with Tables.
+                items:
+                  description: QueryResponseTable is a table representation of a set
+                    of API resources.
+                  properties:
+                    columns:
+                      description: columns is the list of columns in the table.
+                      items:
+                        description: TableColumnDefinition contains information about
+                          a column returned in the Table.
+                        properties:
+                          description:
+                            description: description is a human readable description
+                              of this column.
+                            type: string
+                          format:
+                            description: |-
+                              format is an optional OpenAPI type modifier for this column. A format modifies the type and
+                              imposes additional rules, like date or time formatting for a string. The 'name' format is applied
+                              to the primary identifier column which has type 'string' to assist in clients identifying column
+                              is the resource name.
+                              See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+                            type: string
+                          name:
+                            description: name is a human readable name for the column.
+                            type: string
+                          priority:
+                            description: |-
+                              priority is an integer defining the relative importance of this column compared to others. Lower
+                              numbers are considered higher priority. Columns that may be omitted in limited space scenarios
+                              should be given a higher priority.
+                            format: int32
+                            type: integer
+                          type:
+                            description: |-
+                              type is an OpenAPI type definition for this column, such as number, integer, string, or
+                              array.
+                              See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+                            type: string
+                        required:
+                        - description
+                        - format
+                        - name
+                        - priority
+                        - type
+                        type: object
+                      type: array
+                    groupVersionKind:
+                      description: groupVersionKind is the group, version, and kind
+                        of the objects in the table.
+                      properties:
+                        group:
+                          type: string
+                        kind:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - version
+                      type: object
+                    rows:
+                      description: rows is the list of rows in the table.
+                      items:
+                        description: TableRow is an individual row in a table.
+                        properties:
+                          cells:
+                            description: |-
+                              cells will be as wide as the column definitions array and may contain strings, numbers (float64 or
+                              int64), booleans, simple maps, lists, or null. See the type field of the column definition for a
+                              more detailed description.
+                            items: {}
+                            type: array
+                          conditions:
+                            description: |-
+                              conditions describe additional status of a row that are relevant for a human user. These conditions
+                              apply to the row, not to the object, and will be specific to table output. The only defined
+                              condition type is 'Completed', for a row that indicates a resource that has run to completion and
+                              can be given less visual priority.
+                            items:
+                              description: TableRowCondition allows a row to be marked
+                                with additional information.
+                              properties:
+                                message:
+                                  description: Human readable message indicating details
+                                    about last transition.
+                                  type: string
+                                reason:
+                                  description: (brief) machine readable reason for
+                                    the condition's last transition.
+                                  type: string
+                                status:
+                                  description: Status of the condition, one of True,
+                                    False, Unknown.
+                                  type: string
+                                type:
+                                  description: |-
+                                    Type of row condition. The only defined value is 'Completed' indicating that the
+                                    object this row represents has reached a completed state and may be given less visual
+                                    priority than other rows. Clients are not required to honor any conditions but should
+                                    be consistent where possible about handling the conditions.
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          object:
+                            description: |-
+                              This field contains the requested additional information about each object based on the includeObject
+                              policy when requesting the Table. If "None", this field is empty, if "Object" this will be the
+                              default serialization of the object for the current API version, and if "Metadata" (the default) will
+                              contain the object metadata. Check the returned kind and apiVersion of the object before parsing.
+                              The media type of the object will always match the enclosing list - if this as a JSON table, these
+                              will be JSON encoded objects.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - cells
+                        type: object
+                      type: array
+                  required:
+                  - columns
+                  - groupVersionKind
+                  - rows
+                  type: object
+                type: array
               warnings:
                 description: |-
                   warnings is a list of warnings that occurred while processing the query.
@@ -167,114 +303,158 @@ spec:
               filter:
                 description: filter specifies how to filter the returned objects.
                 properties:
-                  categories:
-                    description: |-
-                      categories is a list of categories to query. If empty, all categories are
-                      queried in the given scope.
-                      Examples: all, managed, composite, claim
-                    items:
-                      type: string
-                    type: array
-                  conditions:
-                    description: |-
-                      conditions is a list of conditions to query. If empty, all conditions are
-                      queried in the given scope.
-                    items:
-                      description: A QueryCondition specifies how to query a condition.
-                      properties:
-                        status:
-                          description: |-
-                            status is the status of condition to query. This is either True, False
-                            or Unknown.
-                          type: string
-                        type:
-                          description: |-
-                            type is the type of condition to query.
-                            Examples: Ready, Synced
-                          type: string
-                      required:
-                      - status
-                      - type
-                      type: object
-                    type: array
                   controlPlane:
                     description: |-
-                      controlPlane specifies which controlplanes to query. If empty, all
-                      controlplanes are queried in the given scope.
+                      controlPlane specifies which control planes to query. If empty, all
+                      control planes are queried in the given scope.
                     properties:
-                      name:
+                      group:
                         description: |-
-                          name is the name of the controlplane to query. If empty, all controlplanes
+                          group is the group of the control plane to query. If empty, all groups
                           are queried in the given scope.
                         type: string
-                      namespace:
+                      name:
                         description: |-
-                          namespace is the namespace of the controlplane to query. If empty, all
-                          namespaces are queried in the given scope.
+                          name is the name of the control plane to query. If empty, all control planes
+                          are queried in the given scope.
                         type: string
                     type: object
-                  group:
+                  objects:
                     description: |-
-                      group is the API group to query. If empty, all groups are queried in the
-                      given scope.
-                    type: string
-                  ids:
-                    description: "\t# ids: [\"id1\",\"id2\"] # to get objects explicitly
-                      by id."
+                      objects specifies what to filter. Objects in the query response will
+                      match all criteria in at least one of the specified filters.
                     items:
-                      type: string
-                    type: array
-                  kind:
-                    description: |-
-                      kind is the API kind to query. If empty, all kinds are queried in the
-                      given scope. The kind is case-insensitive. The kind also matches plural
-                      resources.
-                    type: string
-                  name:
-                    description: |-
-                      name is the name of the object to query. If empty, all objects are queried
-                      in the given scope.
-                    type: string
-                  namespace:
-                    description: |-
-                      namespace is the namespace WITHIN a controlplane to query. If empty,
-                      all namespaces are queried in the given scope.
-                    type: string
-                  owners:
-                    description: |-
-                      owners is a list of owners to query. An object matches if it has at least
-                      one owner in the list.
-                    items:
-                      description: A QueryOwner specifies how to query by owner.
+                      description: |-
+                        QueryFilter specifies what to filter. Objects in the query response will
+                        match all criteria specified in the filter.
                       properties:
-                        group:
-                          description: name is the name of the owner to match.
+                        categories:
+                          description: |-
+                            categories is a list of categories to query.
+                            Examples: all, managed, composite, claim
+                          items:
+                            type: string
+                          type: array
+                        conditions:
+                          description: conditions is a list of conditions to query.
+                          items:
+                            description: A QueryCondition specifies how to query a
+                              condition.
+                            properties:
+                              reason:
+                                description: reason queries based on the reason field
+                                  of the condition.
+                                type: string
+                              status:
+                                description: |-
+                                  status is the status of condition to query. This is either True, False
+                                  or Unknown.
+                                type: string
+                              type:
+                                description: |-
+                                  type is the type of condition to query.
+                                  Examples: Ready, Synced
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          type: array
+                        creationTimestamp:
+                          description: creationTimestamp queries for objects with
+                            a range of creation times.
+                          properties:
+                            after:
+                              format: date-time
+                              type: string
+                            before:
+                              format: date-time
+                              type: string
+                          type: object
+                        groupKind:
+                          description: groupKind is the GroupKinds of objects to query.
+                          properties:
+                            apiGroup:
+                              description: apiGroup is the API group to query. If
+                                empty all groups will be queried.
+                              type: string
+                            kind:
+                              description: |-
+                                kind is kind to query. Kinds are case-insensitive and also match plural
+                                resources. If empty all kinds will be queried.
+                              type: string
+                          type: object
+                        id:
+                          description: id is the object ID to query.
                           type: string
-                        kind:
-                          description: kind is the kind of the owner to match.
+                        jsonpath:
+                          description: |-
+                            jsonpath is a JSONPath filter expression that will be applied to objects
+                            as a filter. It must return a boolean; no objects will be matched if it
+                            returns any other type. jsonpath should be used as a last resort; using
+                            the other filter fields will generally be more efficient.
                           type: string
-                        uid:
-                          description: uid is the uid of the owner to match.
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: labels are the labels of objects to query.
+                          type: object
+                        name:
+                          description: name is the name of objects to query.
+                          type: string
+                        namespace:
+                          description: namespace is the namespace WITHIN a control
+                            plane to query.
                           type: string
                       type: object
                     type: array
-                  sql:
-                    description: |-
-                      sql is a SQL query to query. If empty, all objects are queried in the
-                      given scope.
-
-
-                      The current object can be referenced by the alias "o".
-
-
-                      WARNING: The where clause is highly dependent on the database
-                      schema and might change at any time. The schema is not documented.
-                    type: string
+                required:
+                - objects
                 type: object
+              freshness:
+                description: |-
+                  freshness specifies resource versions per control plane to wait for before
+                  returning results. It's helpful to ensure consistency for read-after-write.
+                items:
+                  description: |-
+                    Freshness specifies a resource version per control plane to wait for before
+                    returning results. It's helpful to ensure consistency for read-after-write.
+                  properties:
+                    controlPlane:
+                      description: |-
+                        controlPlane is the name of the control plane to check for freshness of the data.
+                        In case of Query, the name is defaulted and must match the control plane
+                        name of the request.
+                      type: string
+                    group:
+                      description: |-
+                        group is the group of the control plane to check for freshness of
+                        the data. In case of GroupQuery or Query, the group is defaulted and
+                        must match the group of the request.
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        resourceVersion is the resource version of the specified control plane
+                        to wait for before executing the query. Normal request timeouts apply.
+                        The resourceVersion is a large integer, returned by previous queries or
+                        by requests against the control plane Kubernetes API.
+
+                        Note that resource versions between control planes are not correlated.
+                      minLength: 1
+                      pattern: ^[0-9]+$
+                      type: string
+                  required:
+                  - controlPlane
+                  - group
+                  - resourceVersion
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - controlPlane
+                x-kubernetes-list-type: map
               limit:
                 description: |-
                   limit is the maximal number of objects to return. Defaulted to 100.
-
 
                   Note that a limit in a relation subsumes all the children of all parents,
                   i.e. a small limit only makes sense if there is only a single parent,
@@ -285,7 +465,7 @@ spec:
                 properties:
                   controlPlane:
                     description: |-
-                      controlPlane specifies that the controlplane name and namespace of the
+                      controlPlane specifies that the control plane name and namespace of the
                       object should be returned.
                     type: boolean
                   id:
@@ -298,7 +478,7 @@ spec:
                   mutablePath:
                     description: |-
                       mutablePath specifies whether to return the mutable path of the object,
-                      i.e. the path to the object in the controlplane Kubernetes API.
+                      i.e. the path to the object in the control plane Kubernetes API.
                     type: boolean
                   object:
                     description: |-
@@ -313,105 +493,113 @@ spec:
                       description: A QueryRelation specifies how to return objects
                         in a relation.
                       properties:
-                        filter:
-                          description: filter specifies how to filter the returned
+                        filters:
+                          description: filters specifies how to filter the returned
                             objects.
-                          properties:
-                            categories:
-                              description: |-
-                                categories is a list of categories to query. If empty, all categories are
-                                queried in the given scope.
-                                Examples: all, managed, composite, claim
-                              items:
-                                type: string
-                              type: array
-                            conditions:
-                              description: |-
-                                conditions is a list of conditions to query. If empty, all conditions are
-                                queried in the given scope.
-                              items:
-                                description: A QueryCondition specifies how to query
-                                  a condition.
+                          items:
+                            description: |-
+                              QueryFilter specifies what to filter. Objects in the query response will
+                              match all criteria specified in the filter.
+                            properties:
+                              categories:
+                                description: |-
+                                  categories is a list of categories to query.
+                                  Examples: all, managed, composite, claim
+                                items:
+                                  type: string
+                                type: array
+                              conditions:
+                                description: conditions is a list of conditions to
+                                  query.
+                                items:
+                                  description: A QueryCondition specifies how to query
+                                    a condition.
+                                  properties:
+                                    reason:
+                                      description: reason queries based on the reason
+                                        field of the condition.
+                                      type: string
+                                    status:
+                                      description: |-
+                                        status is the status of condition to query. This is either True, False
+                                        or Unknown.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type is the type of condition to query.
+                                        Examples: Ready, Synced
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                type: array
+                              creationTimestamp:
+                                description: creationTimestamp queries for objects
+                                  with a range of creation times.
                                 properties:
-                                  status:
-                                    description: |-
-                                      status is the status of condition to query. This is either True, False
-                                      or Unknown.
+                                  after:
+                                    format: date-time
                                     type: string
-                                  type:
-                                    description: |-
-                                      type is the type of condition to query.
-                                      Examples: Ready, Synced
+                                  before:
+                                    format: date-time
                                     type: string
-                                required:
-                                - status
-                                - type
                                 type: object
-                              type: array
-                            group:
-                              description: |-
-                                group is the API group to query. If empty, all groups are queried in the
-                                given scope.
-                              type: string
-                            kind:
-                              description: |-
-                                kind is the API kind to query. If empty, all kinds are queried in the
-                                given scope. The kind is case-insensitive. The kind also matches plural
-                                resources.
-                              type: string
-                            name:
-                              description: |-
-                                name is the name of the object to query. If empty, all objects are queried
-                                in the given scope.
-                              type: string
-                            namespace:
-                              description: |-
-                                namespace is the namespace WITHIN a controlplane to query. If empty,
-                                all namespaces are queried in the given scope.
-                              type: string
-                            owners:
-                              description: |-
-                                owners is a list of owners to query. An object matches if it has at least
-                                one owner in the list.
-                              items:
-                                description: A QueryOwner specifies how to query by
-                                  owner.
+                              groupKind:
+                                description: groupKind is the GroupKinds of objects
+                                  to query.
                                 properties:
-                                  group:
-                                    description: name is the name of the owner to
-                                      match.
+                                  apiGroup:
+                                    description: apiGroup is the API group to query.
+                                      If empty all groups will be queried.
                                     type: string
                                   kind:
-                                    description: kind is the kind of the owner to
-                                      match.
-                                    type: string
-                                  uid:
-                                    description: uid is the uid of the owner to match.
+                                    description: |-
+                                      kind is kind to query. Kinds are case-insensitive and also match plural
+                                      resources. If empty all kinds will be queried.
                                     type: string
                                 type: object
-                              type: array
-                            sql:
-                              description: |-
-                                sql is a SQL query to query. If empty, all objects are queried in the
-                                given scope.
-
-
-                                The current object can be referenced by the alias "o".
-
-
-                                WARNING: The where clause is highly dependent on the database
-                                schema and might change at any time. The schema is not documented.
-                              type: string
-                          type: object
+                              id:
+                                description: id is the object ID to query.
+                                type: string
+                              jsonpath:
+                                description: |-
+                                  jsonpath is a JSONPath filter expression that will be applied to objects
+                                  as a filter. It must return a boolean; no objects will be matched if it
+                                  returns any other type. jsonpath should be used as a last resort; using
+                                  the other filter fields will generally be more efficient.
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: labels are the labels of objects to query.
+                                type: object
+                              name:
+                                description: name is the name of objects to query.
+                                type: string
+                              namespace:
+                                description: namespace is the namespace WITHIN a control
+                                  plane to query.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                     description: |-
                       relations specifies which relations to query and what to return.
                       Relation names are predefined strings relative to the release of
                       Spaces.
 
-
                       Examples: owners, descendants, resources, events, or their transitive
                       equivalents owners+, descendants+, resources+.
+                    type: object
+                  table:
+                    description: table specifies whether to return the object in a
+                      table format.
+                    properties:
+                      grouping:
+                        description: |-
+                          grouping specifies how to group the returned objects into multiple
+                          tables where every table can have different sets of columns.
+                        type: string
                     type: object
                 type: object
               order:
@@ -423,8 +611,15 @@ spec:
                   description: A QueryOrder specifies how to order. Exactly one of
                     the fields must be set.
                   properties:
+                    apiGroup:
+                      description: APIGroup specifies how to order by API group.
+                      enum:
+                      - Asc
+                      - Desc
+                      type: string
                     cluster:
-                      description: controlPlane specifies how to order by controlplane.
+                      description: controlPlane specifies how to order by control
+                        plane name.
                       type: string
                     creationTimestamp:
                       description: creationTimestamp specifies how to order by creation
@@ -434,7 +629,7 @@ spec:
                       - Desc
                       type: string
                     group:
-                      description: group specifies how to order by group.
+                      description: group specifies how to order by control plane group.
                       enum:
                       - Asc
                       - Desc
@@ -470,7 +665,6 @@ spec:
                       the format cannot be relied on. It is returned by the server in the
                       response to a previous query. If neither first nor cursor is specified,
                       objects are returned from the beginning.
-
 
                       Note that cursor values are not stable under different orderings.
                     type: string


### PR DESCRIPTION
FOr posterity here are the steps I used to produce these updates:

1. Installed controller-gen globally: `go install [sigs.k8s.io/controller-tools/cmd/controller-gen@latest`
2. Added binary to my path in .zshrc: `export PATH=$PATH:$(go env GOPATH)/bin`
3. Reloaded .zshrc: `source ~/.zshrc`
4. Call controller-gen: `controller-gen paths=github.com/upbound/up-sdk-go/apis/query/v1alpha2/... crd:crdVersions=v1 output:artifacts:config=./crds`
5. Copied the generated yaml files to docs project at: `~/Development/upbound/docs/content/all-spaces/query-api/yaml`
6. Cloned and prepared https://github.com/tr0njavolta/api-gen
7. Executed: `python3 ./api-generator.py -w -crd ~/Development/upbound/docs/content/all-spaces/query-api/yaml -desc ~/Development/upbound/docs/content/all-spaces/query-api/ -o yaml`