### PR TITLE
Update self-hosted Spaces docs to reflect profile changes

### DIFF
--- a/content/all-spaces/self-hosted-spaces/aws-deployment.md
+++ b/content/all-spaces/self-hosted-spaces/aws-deployment.md
@@ -214,7 +214,9 @@ If the preceding command doesn't return a load balancer address then your provid
 
 ## Configure the up CLI
 
-With your kubeconfig pointed at the Kubernetes cluster where you installed Upbound Spaces, create a new profile in the `up` CLI. This profile will be used to interact with your Space:
+With your kubeconfig pointed at the Kubernetes cluster where you installed
+Upbound Spaces, create a new profile in the `up` CLI. This profile interacts
+with your Space:
 
 ```bash
 up profile create --use ${SPACES_CLUSTER_NAME} --type=disconnected --organization ${UPBOUND_ACCOUNT}
@@ -225,9 +227,11 @@ Optionally, log in to your Upbound account using the new profile so you can use 
 ```bash
 up login
 ```
+<!-- vale Google.Headings = NO -->
 
 ## Connect to your Space
 
+<!-- vale Google.Headings = YES -->
 Use `up ctx` to create a kubeconfig context pointed at your new Space:
 
 ```bash
@@ -242,7 +246,7 @@ You can now create a managed control plane with the `up` CLI:
 up ctp create ctp1
 ```
 
-Alternatively, you can create a control plane with kubectl:
+You can also create a control plane with kubectl:
 
 ```yaml
 cat <<EOF | kubectl apply -f -

--- a/content/all-spaces/self-hosted-spaces/azure-deployment.md
+++ b/content/all-spaces/self-hosted-spaces/azure-deployment.md
@@ -117,7 +117,7 @@ kubectl wait deployment -n cert-manager cert-manager-webhook --for condition=Ava
 ### Install ingress-nginx
 
 Starting with Spaces v1.10.0, you need to configure the ingress-nginx
-controller to allow SSL-passthrough mode. You can do so by passing the 
+controller to allow SSL-passthrough mode. You can do so by passing the
 `--enable-ssl-passthrough=true` command-line option to the controller.
 The following Helm install command enables this with the `controller.extraArgs`
 parameter:
@@ -182,7 +182,9 @@ If the preceding command doesn't return a load balancer address then your provid
 
 ## Configure the up CLI
 
-With your kubeconfig pointed at the Kubernetes cluster where you installed Upbound Spaces, create a new profile in the `up` CLI. This profile will be used to interact with your Space:
+With your kubeconfig pointed at the Kubernetes cluster where you installed
+Upbound Spaces, create a new profile in the `up` CLI. This profile interacts
+with your Space:
 
 ```bash
 up profile create --use ${SPACES_CLUSTER_NAME} --type=disconnected --organization ${UPBOUND_ACCOUNT}
@@ -193,9 +195,11 @@ Optionally, log in to your Upbound account using the new profile so you can use 
 ```bash
 up login
 ```
+<!-- vale Google.Headings = NO -->
 
 ## Connect to your Space
 
+<!-- vale Google.Headings = YES -->
 Use `up ctx` to create a kubeconfig context pointed at your new Space:
 
 ```bash
@@ -210,7 +214,7 @@ You can now create a managed control plane with the `up` CLI:
 up ctp create ctp1
 ```
 
-Alternatively, you can create a control plane with kubectl:
+You can also create a control plane with kubectl:
 
 ```yaml
 cat <<EOF | kubectl apply -f -

--- a/content/all-spaces/self-hosted-spaces/gcp-deployment.md
+++ b/content/all-spaces/self-hosted-spaces/gcp-deployment.md
@@ -179,7 +179,9 @@ If the preceding command doesn't return a load balancer address then your provid
 
 ## Configure the up CLI
 
-With your kubeconfig pointed at the Kubernetes cluster where you installed Upbound Spaces, create a new profile in the `up` CLI. This profile will be used to interact with your Space:
+With your kubeconfig pointed at the Kubernetes cluster where you installed
+Upbound Spaces, create a new profile in the `up` CLI. This profile interacts
+with your Space:
 
 ```bash
 up profile create --use ${SPACES_CLUSTER_NAME} --type=disconnected --organization ${UPBOUND_ACCOUNT}
@@ -190,9 +192,11 @@ Optionally, log in to your Upbound account using the new profile so you can use 
 ```bash
 up login
 ```
+<!-- vale Google.Headings = NO -->
 
 ## Connect to your Space
 
+<!-- vale Google.Headings = YES -->
 Use `up ctx` to create a kubeconfig context pointed at your new Space:
 
 ```bash
@@ -206,8 +210,7 @@ You can now create a managed control plane with the `up` CLI:
 ```bash
 up ctp create ctp1
 ```
-
-Alternatively, you can create a control plane with kubectl:
+You can also create a control plane with kubectl:
 
 ```yaml
 cat <<EOF | kubectl apply -f -

--- a/content/all-spaces/self-hosted-spaces/quickstart/_index.md
+++ b/content/all-spaces/self-hosted-spaces/quickstart/_index.md
@@ -144,8 +144,11 @@ up ctx -
 {{< hint "tip" >}}
 Learn how to use the up CLI to navigate around Upbound by reading the [up ctx command reference]({{<ref "reference/cli/contexts">}}).
 {{< /hint >}}
+
 <!-- vale Google.Headings = NO -->
+
 ## Connect your Space to Upbound
+
 <!-- vale Google.Headings = YES -->
 
 [Upbound]({{<ref "console">}}) allows you to connect self-hosted Spaces and enables a streamlined operations and debugging experience in your Console.


### PR DESCRIPTION
Users now need a profile to interact with Spaces, even when they're self-hosted. Update the self-hosted Spaces setup docs to include creating a profile and update the `up ctx` commands to work correctly with the new profiles. Update the local quick-start to work with the profile created by `up space init`.
