### PR TITLE
fixes release notes sorting

### DIFF
--- a/content/reference/rel-notes/mcp-connector-v0.3.6.md
+++ b/content/reference/rel-notes/mcp-connector-v0.3.6.md
@@ -4,6 +4,7 @@ version: "v0.3.6"
 date: 2024-03-15
 tocHidden: true
 product: "mcp-connector"
+version_sort_key: "0000.0003.0006"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/mcp-connector-v0.3.7.md
+++ b/content/reference/rel-notes/mcp-connector-v0.3.7.md
@@ -4,6 +4,7 @@ version: "v0.3.7"
 date: 2024-03-21
 tocHidden: true
 product: "mcp-connector"
+version_sort_key: "0000.0003.0007"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/mcp-connector-v0.3.8.md
+++ b/content/reference/rel-notes/mcp-connector-v0.3.8.md
@@ -4,6 +4,7 @@ version: "v0.3.8"
 date: 2024-03-21
 tocHidden: true
 product: "mcp-connector"
+version_sort_key: "0000.0003.0008"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/mcp-connector-v0.4.0.md
+++ b/content/reference/rel-notes/mcp-connector-v0.4.0.md
@@ -4,6 +4,7 @@ version: "v0.4.0"
 date: 2024-04-29
 tocHidden: true
 product: "mcp-connector"
+version_sort_key: "0000.0004.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/mcp-connector-v0.5.0.md
+++ b/content/reference/rel-notes/mcp-connector-v0.5.0.md
@@ -4,6 +4,7 @@ version: "v0.5.0"
 date: 2024-06-06
 tocHidden: true
 product: "mcp-connector"
+version_sort_key: "0000.0005.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/mcp-connector-v0.6.0.md
+++ b/content/reference/rel-notes/mcp-connector-v0.6.0.md
@@ -4,6 +4,7 @@ version: "v0.6.0"
 date: 2024-06-15
 tocHidden: true
 product: "mcp-connector"
+version_sort_key: "0000.0006.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/mcp-connector-v0.6.1.md
+++ b/content/reference/rel-notes/mcp-connector-v0.6.1.md
@@ -4,6 +4,7 @@ version: "v0.6.1"
 date: 2024-06-29
 tocHidden: true
 product: "mcp-connector"
+version_sort_key: "0000.0006.0001"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/mcp-connector-v0.7.0.md
+++ b/content/reference/rel-notes/mcp-connector-v0.7.0.md
@@ -4,6 +4,7 @@ version: "v0.7.0"
 date: 2024-08-16
 tocHidden: true
 product: "mcp-connector"
+version_sort_key: "0000.0007.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/mcp-connector-v0.8.0.md
+++ b/content/reference/rel-notes/mcp-connector-v0.8.0.md
@@ -4,6 +4,7 @@ version: "v0.8.0"
 date: 2024-11-01
 tocHidden: true
 product: "mcp-connector"
+version_sort_key: "0000.0008.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.0.0.md
+++ b/content/reference/rel-notes/spaces-v1.0.0.md
@@ -4,6 +4,7 @@ version: "v1.0.0"
 date: 2023-08-28
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0000.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.0.1.md
+++ b/content/reference/rel-notes/spaces-v1.0.1.md
@@ -4,6 +4,7 @@ version: "v1.0.1"
 date: 2023-08-31
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0000.0001"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.1.0.md
+++ b/content/reference/rel-notes/spaces-v1.1.0.md
@@ -4,6 +4,7 @@ version: "v1.1.0"
 date: 2023-10-10
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0001.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.10.0.md
+++ b/content/reference/rel-notes/spaces-v1.10.0.md
@@ -4,6 +4,7 @@ version: "v1.10.0"
 date: 2025-01-07
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0010.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.10.1.md
+++ b/content/reference/rel-notes/spaces-v1.10.1.md
@@ -4,6 +4,7 @@ version: "v1.10.1"
 date: 2025-01-13
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0010.0001"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.10.2.md
+++ b/content/reference/rel-notes/spaces-v1.10.2.md
@@ -4,6 +4,7 @@ version: "v1.10.2"
 date: 2025-02-13
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0010.0002"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.10.3.md
+++ b/content/reference/rel-notes/spaces-v1.10.3.md
@@ -4,6 +4,7 @@ version: "v1.10.3"
 date: 2025-02-13
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0010.0003"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.10.4.md
+++ b/content/reference/rel-notes/spaces-v1.10.4.md
@@ -4,6 +4,7 @@ version: "v1.10.4"
 date: 2025-03-12
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0010.0004"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.11.0.md
+++ b/content/reference/rel-notes/spaces-v1.11.0.md
@@ -4,6 +4,7 @@ version: "v1.11.0"
 date: 2025-02-04
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0011.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.11.1.md
+++ b/content/reference/rel-notes/spaces-v1.11.1.md
@@ -4,6 +4,7 @@ version: "v1.11.1"
 date: 2025-02-13
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0011.0001"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.11.2.md
+++ b/content/reference/rel-notes/spaces-v1.11.2.md
@@ -4,6 +4,7 @@ version: "v1.11.2"
 date: 2025-03-12
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0011.0002"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.2.0.md
+++ b/content/reference/rel-notes/spaces-v1.2.0.md
@@ -4,6 +4,7 @@ version: "v1.2.0"
 date: 2024-02-01
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0002.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.2.1.md
+++ b/content/reference/rel-notes/spaces-v1.2.1.md
@@ -4,6 +4,7 @@ version: "v1.2.1"
 date: 2024-02-08
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0002.0001"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.2.2.md
+++ b/content/reference/rel-notes/spaces-v1.2.2.md
@@ -4,6 +4,7 @@ version: "v1.2.2"
 date: 2024-03-01
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0002.0002"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.2.3.md
+++ b/content/reference/rel-notes/spaces-v1.2.3.md
@@ -4,6 +4,7 @@ version: "v1.2.3"
 date: 2024-03-01
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0002.0003"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.2.4.md
+++ b/content/reference/rel-notes/spaces-v1.2.4.md
@@ -4,6 +4,7 @@ version: "v1.2.4"
 date: 2024-03-13
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0002.0004"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.3.0.md
+++ b/content/reference/rel-notes/spaces-v1.3.0.md
@@ -4,6 +4,7 @@ version: "v1.3.0"
 date: 2024-04-30
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0003.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.3.1.md
+++ b/content/reference/rel-notes/spaces-v1.3.1.md
@@ -4,6 +4,7 @@ version: "v1.3.1"
 date: 2024-05-07
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0003.0001"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.4.0.md
+++ b/content/reference/rel-notes/spaces-v1.4.0.md
@@ -4,6 +4,7 @@ version: "v1.4.0"
 date: 2024-06-07
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0004.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.4.1.md
+++ b/content/reference/rel-notes/spaces-v1.4.1.md
@@ -4,6 +4,7 @@ version: "v1.4.1"
 date: 2024-06-20
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0004.0001"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.4.2.md
+++ b/content/reference/rel-notes/spaces-v1.4.2.md
@@ -4,6 +4,7 @@ version: "v1.4.2"
 date: 2024-06-26
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0004.0002"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.5.0.md
+++ b/content/reference/rel-notes/spaces-v1.5.0.md
@@ -4,6 +4,7 @@ version: "v1.5.0"
 date: 2024-07-01
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0005.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.6.0.md
+++ b/content/reference/rel-notes/spaces-v1.6.0.md
@@ -4,6 +4,7 @@ version: "v1.6.0"
 date: 2024-08-06
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0006.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.6.1.md
+++ b/content/reference/rel-notes/spaces-v1.6.1.md
@@ -4,6 +4,7 @@ version: "v1.6.1"
 date: 2024-08-14
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0006.0001"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.7.0.md
+++ b/content/reference/rel-notes/spaces-v1.7.0.md
@@ -4,6 +4,7 @@ version: "v1.7.0"
 date: 2024-09-02
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0007.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.7.1.md
+++ b/content/reference/rel-notes/spaces-v1.7.1.md
@@ -4,6 +4,7 @@ version: "v1.7.1"
 date: 2024-09-12
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0007.0001"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.7.2.md
+++ b/content/reference/rel-notes/spaces-v1.7.2.md
@@ -4,6 +4,7 @@ version: "v1.7.2"
 date: 2024-09-13
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0007.0002"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.8.0.md
+++ b/content/reference/rel-notes/spaces-v1.8.0.md
@@ -4,6 +4,7 @@ version: "v1.8.0"
 date: 2024-10-08
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0008.0000"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.9.1.md
+++ b/content/reference/rel-notes/spaces-v1.9.1.md
@@ -4,6 +4,7 @@ version: "v1.9.1"
 date: 2024-11-07
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0009.0001"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.9.2.md
+++ b/content/reference/rel-notes/spaces-v1.9.2.md
@@ -4,6 +4,7 @@ version: "v1.9.2"
 date: 2024-11-08
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0009.0002"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.9.3.md
+++ b/content/reference/rel-notes/spaces-v1.9.3.md
@@ -4,6 +4,7 @@ version: "v1.9.3"
 date: 2024-11-12
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0009.0003"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.9.4.md
+++ b/content/reference/rel-notes/spaces-v1.9.4.md
@@ -4,6 +4,7 @@ version: "v1.9.4"
 date: 2024-11-14
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0009.0004"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.9.5.md
+++ b/content/reference/rel-notes/spaces-v1.9.5.md
@@ -4,6 +4,7 @@ version: "v1.9.5"
 date: 2024-12-09
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0009.0005"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.9.6.md
+++ b/content/reference/rel-notes/spaces-v1.9.6.md
@@ -4,6 +4,7 @@ version: "v1.9.6"
 date: 2025-02-13
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0009.0006"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.9.7.md
+++ b/content/reference/rel-notes/spaces-v1.9.7.md
@@ -4,6 +4,7 @@ version: "v1.9.7"
 date: 2025-02-13
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0009.0007"
 ---
 <!-- vale off -->
 

--- a/content/reference/rel-notes/spaces-v1.9.8.md
+++ b/content/reference/rel-notes/spaces-v1.9.8.md
@@ -4,6 +4,7 @@ version: "v1.9.8"
 date: 2025-03-12
 tocHidden: true
 product: "spaces"
+version_sort_key: "0001.0009.0008"
 ---
 <!-- vale off -->
 

--- a/themes/upbound/layouts/shortcodes/relnotes.html
+++ b/themes/upbound/layouts/shortcodes/relnotes.html
@@ -1,15 +1,15 @@
 {{ $product := .Get "product" }}
-{{ $relNotes := where .Site.RegularPages "File.Dir" "eq" "reference/rel-notes/"
-}}
+{{ $relNotes := where .Site.RegularPages "File.Dir" "eq" "reference/rel-notes/" }}
 {{ $releases := where $relNotes "Params.product" "eq" $product }}
 
+{{ $sortedReleases := sort $releases "Params.version_sort_key" "desc" }}
+
 <div class="release-notes-container">
-    {{ range sort $releases "Date" "desc" }}
+    {{ range $sortedReleases }}
     <article class="release-note">
         <header>
             <h3 id="{{ .File.ContentBaseName }}">{{ .Title }}</h3>
-            <p class="date"><strong>Release Date:</strong> {{ .Date.Format "2006-01-02"
-                }}</p>
+            <p class="date"><strong>Release Date:</strong> {{ .Date.Format "2006-01-02" }}</p>
         </header>
         <div class="content">
             {{ .Content | markdownify }}


### PR DESCRIPTION
#695 


updates front matter with:
```
---
title: "Spaces vX.YY.Z"
version: "vX.YY.Z"
date: 2023-10-10
tocHidden: true
product: "spaces"
version_sort_key: "000X.00YY.000Z"
---
```
with X, YY, Z as the semantic versioning numbers