### PR TITLE
[security] Pin to safe version after CVE-2025-30066

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@039afcd1024c210363c9d3fc8fd07e1f3fcf2867 # v35.9.3
         with:
           files: content/**
 


### PR DESCRIPTION
See https://github.com/advisories/GHSA-mrrh-fwg8-r2c3