### PR TITLE
Add a more prominent warning about the minimum version for projects

### DIFF
--- a/content/build/_index.md
+++ b/content/build/_index.md
@@ -10,10 +10,16 @@ category: "guides"
 
 ---
 
+{{<hint "warning">}}
+Configurations built using control plane projects require Crossplane v1.18 or
+newer. They will fail to install on older versions of Crossplane.
+{{< /hint >}}
+
 Authoring and building control plane projects is the best way to get hands-on
 experience with Upbound.
 
 This section teaches you how to:
+
 - Create a control plane project and add providers and other dependencies
 - Author an API
 - Author compositions and composition functions


### PR DESCRIPTION
Configurations built from projects can only be installed on Crossplane v1.18 and newer. Make this warning more prominent in the docs so users aren't surprised.
