### PR TITLE
Add release notes for mcp connector v0.8.1 and v0.9.0

### DIFF
--- a/content/reference/rel-notes/mcp-connector-v0.8.1.md
+++ b/content/reference/rel-notes/mcp-connector-v0.8.1.md
@@ -1,0 +1,15 @@
+---
+title: "MCP Connector v0.8.1"
+version: "v0.8.1"
+date: 2025-04-28
+tocHidden: true
+product: "mcp-connector"
+version_sort_key: "0000.0008.0001"
+---
+<!-- vale off -->
+
+#### What's Changed
+
+- Ability to override app cluster id via `clusterID` helm value for migration scenarios.
+
+<!-- vale on -->

--- a/content/reference/rel-notes/mcp-connector-v0.9.0.md
+++ b/content/reference/rel-notes/mcp-connector-v0.9.0.md
@@ -1,0 +1,18 @@
+---
+title: "MCP Connector v0.9.0"
+version: "v0.9.0"
+date: 2025-04-28
+tocHidden: true
+product: "mcp-connector"
+version_sort_key: "0000.0009.0000"
+---
+<!-- vale off -->
+
+#### What's Changed
+
+- Upgraded Kubernetes library dependencies from 1.29 to 1.32.
+- Apiserver Audit-IDs are propagated to the requests to the connected MCP for easier log correlation.
+- Fixed an issue with binary architecture in `arm64` images.
+- Fixed an issue that was causing namespace deletions to get blocked.
+
+<!-- vale on -->


### PR DESCRIPTION
Adds release notes for mcp-connector [v0.9.0](https://github.com/upbound/mcp-connector/releases/tag/v0.9.0) and the patch release [v0.8.1](https://github.com/upbound/mcp-connector/releases/tag/v0.8.1)