### PR TITLE
update SSO and SCIM info

### DIFF
--- a/content/operate/accounts/authentication/enable-sso.md
+++ b/content/operate/accounts/authentication/enable-sso.md
@@ -13,7 +13,12 @@ Upbound allows organizations to configure single sign-on (SSO) to manage user ac
 
 ## Introduction
 
-Upbound offers SSO and Directory Sync in a customized wizard setup. You can configure SSO only or add Directory Sync after you enable SSO. The setup will require interactions with Upbound. The only information that you will need to provide is your Upbound organization name and top level domain.
+Upbound offers SSO and Directory Sync in a customized wizard setup. You can configure SSO only or add Directory Sync after you enable SSO.
+
+{{< hint "important" >}}
+You must contact Upbound to enable and configure SSO. You will need to provide your Upbound organization name and top-level domain.
+{{</ hint >}}
+
 
 <!-- vale off -->
 ### Single sign-on
@@ -44,11 +49,11 @@ To enable SSO, you need:
 
 <!-- vale off -->
 ## Configure your identity provider for single sign-on
-<!-- vale on -->
 
-After contacting the support team for SSO access, Upbound sends a link to configure your IdP with Upbound. You can use the predefined workflows for your specific IdP or create a custom SAML or OIDC connection.
 
-<!-- vale off -->
+After you contact the support team for SSO access, Upbound will send a link to configure your IdP with Upbound. You can use the predefined workflows for your specific IdP or create a custom SAML or OIDC connection.
+
+
 ### Enable single sign-on
 <!-- vale on -->
 
@@ -71,7 +76,7 @@ After you enable SSO to your IdP and test the connection, contact Upbound suppor
 
 ### Configure SCIM
 
-After Upbound enabled SSO, please contact [the Upbound support team](https://www.upbound.io/contact) to obtain a link for your SCIM setup. Then walk through the workflow in your provided link.
+After Upbound enables SSO, please contact [the Upbound support team](https://www.upbound.io/contact) to obtain a link for your SCIM setup. Then walk through the workflow in your provided link.
 <!-- vale on -->
 
 ## Considerations


### PR DESCRIPTION
Updated doc based on recent learning during customer onboarding.

- Added info that a separate link can be requested from Upbound for SCIM setup.
- Added info that only org name and top level domain are needed for Upbound to generate the SSO link.