### PR TITLE
feat(bump): up-cli to v0.39.0

### DIFF
--- a/content/connect/gitops.md
+++ b/content/connect/gitops.md
@@ -57,7 +57,7 @@ controller:
 
   initContainers:
     - name: up-plugin
-      image: xpkg.upbound.io/upbound/up-cli:v0.39.0-0.rc.0.102.g3f384b68
+      image: xpkg.upbound.io/upbound/up-cli:v0.39.0
       command: ["cp"]
       args:
         - /usr/local/bin/up
@@ -82,7 +82,7 @@ server:
 
   initContainers:
     - name: up-plugin
-      image: xpkg.upbound.io/upbound/up-cli:v0.39.0-0.rc.0.102.g3f384b68
+      image: xpkg.upbound.io/upbound/up-cli:v0.39.0
       command: ["cp"]
       args:
         - /usr/local/bin/up


### PR DESCRIPTION
tested via https://github.com/upbound/configuration-gitops-argocd/pull/58