### PR TITLE
fix(py): remove apiVersion and kind

### DIFF
--- a/content/build/control-plane-projects/authoring-compositions/python/_index.md
+++ b/content/build/control-plane-projects/authoring-compositions/python/_index.md
@@ -54,8 +54,6 @@ def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
 
     # Tell Crossplane to compose an S3 bucket.
     desired_bucket = bucketv1beta1.Bucket(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="Bucket",
         spec=bucketv1beta1.Spec(
             forProvider=bucketv1beta1.ForProvider(
                 region=observed_xr.spec.region or "us-west-2",
@@ -103,8 +101,6 @@ def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
     params = observed_xr.spec.parameters
 
     desired_bucket = bucketv1beta1.Bucket(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="Bucket",
         spec=bucketv1beta1.Spec(
             forProvider=bucketv1beta1.ForProvider(
                 region=params.region,
@@ -131,8 +127,6 @@ def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
     ]
 
     desired_acl = aclv1beta1.BucketACL(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="BucketACL",
         spec=aclv1beta1.Spec(
             forProvider=aclv1beta1.ForProvider(
                 region=params.region,
@@ -144,8 +138,6 @@ def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
     resource.update(rsp.desired.resources["acl"], desired_acl)
 
     desired_boc = bocv1beta1.BucketOwnershipControls(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="BucketOwnershipControls",
         spec=bocv1beta1.Spec(
             forProvider=bocv1beta1.ForProvider(
                 region=params.region,
@@ -161,8 +153,6 @@ def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
     resource.update(rsp.desired.resources["boc"], desired_boc)
 
     desired_pab = pabv1beta1.BucketPublicAccessBlock(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="BucketPublicAccessBlock",
         spec=pabv1beta1.Spec(
             forProvider=pabv1beta1.ForProvider(
                 region=params.region,
@@ -177,8 +167,6 @@ def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
     resource.update(rsp.desired.resources["pab"], desired_pab)
 
     desired_sse = ssev1beta1.BucketServerSideEncryptionConfiguration(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="BucketServerSideEncryptionConfiguration",
         spec=ssev1beta1.Spec(
             forProvider=ssev1beta1.ForProvider(
                 region=params.region,
@@ -204,8 +192,6 @@ def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
         return
 
     desired_versioning = verv1beta1.BucketVersioning(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="BucketVersioning",
         spec=verv1beta1.Spec(
             forProvider=verv1beta1.ForProvider(
                 region=params.region,

--- a/content/build/control-plane-projects/authoring-compositions/python/models.md
+++ b/content/build/control-plane-projects/authoring-compositions/python/models.md
@@ -95,8 +95,6 @@ from .model.io.upbound.aws.s3.bucket import v1beta1
 
 def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
     bucket = v1beta1.Bucket(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="Bucket",
         spec=v1beta1.Spec(
             forProvider=v1beta1.ForProvider(
                 region="us-west-1",
@@ -208,8 +206,6 @@ def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
     observed_xr = v1alpha1.XStorageBucket(**req.observed.composite.resource)
 
     desired_bucket = bucketv1beta1.Bucket(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="Bucket",
         spec=bucketv1beta1.Spec(
             forProvider=bucketv1beta1.ForProvider(
                 region=observed_xr.spec.region,  # Warning: Argument of type "str | None" cannot be assigned to parameter "region" of type "str"
@@ -240,8 +236,6 @@ def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
         region = observed_xr.spec.
 
     desired_bucket = bucketv1beta1.Bucket(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="Bucket",
         spec=bucketv1beta1.Spec(
             forProvider=bucketv1beta1.ForProvider(
                 region=observed_xr.spec.region or "us-west-2",  # Default to "us-west-2" if region is None.
@@ -267,8 +261,6 @@ def compose(req: fnv1.RunFunctionRequest, rsp: fnv1.RunFunctionResponse):
     observed_xr = v1alpha1.XStorageBucket(**req.observed.composite.resource)
 
     desired_bucket = bucketv1beta1.Bucket(
-        apiVersion="s3.aws.upbound.io/v1beta1",
-        kind="Bucket",
         from .model.io.k8s.apimachinery.pkg.apis.meta import v1 as metav1
         metadata=metav1.ObjectMeta(
             name=observed_xr.metadata.name + "-bucket", # type: ignore  # The observed XR will always have a name.


### PR DESCRIPTION
we have now default for apiVersion and kind - so we need to remove it from our examples
https://github.com/upbound/example-project-aws/pull/17
https://github.com/upbound/example-project-aws/pull/18