### PR TITLE
fix link

### DIFF
--- a/docs/deploy/self-hosted-spaces/billing.md
+++ b/docs/deploy/self-hosted-spaces/billing.md
@@ -296,4 +296,4 @@ You can find full instructions and command options in the up [CLI reference][cli
 [export]: /apis-cli/cli-reference/#up-space-billing-get
 [cli-reference]: /apis-cli/cli-reference/#up-space-billing
 [flagship-product]: https://www.upbound.io/product/upbound
-[workload-identity-configuration-documentation]: https://docs.upbound.io/all-spaces/workload-id/
+[workload-identity-configuration-documentation]: https://docs.upbound.io/operate/accounts/authentication/oidc-configuration


### PR DESCRIPTION
- fixed broken link to non-existent doc for workload-identity-configuration-documentation pointing to OIDC auth config info.