### PR TITLE
Clarify the provider VPA instructions

### DIFF
--- a/docs/manuals/uxp/howtos/self-managed-uxp/provider-vpa.md
+++ b/docs/manuals/uxp/howtos/self-managed-uxp/provider-vpa.md
@@ -65,7 +65,7 @@ helm -n vpa install vpa cowboysysop/vertical-pod-autoscaler --version 10.2.1 --c
 
 ## Enable provider autoscaling
 
-Ensure you have the `upbound-stable` Helm repository ocnfigured:
+Ensure you have the `upbound-stable` Helm repository configured:
 
 ```bash
 helm repo add upbound-stable https://charts.upbound.io/stable


### PR DESCRIPTION
Three tweaks to the VPA instructions:

1. Call out in the Prerequisites section that the metrics-server and VPA controller will be installed as part of the guide (the user doesn't need to figure these out before proceeding).
2. Update the helm repository used in the `helm upgrade` that enables VPA to the location that we'll document.
3. Describe how a DeploymentRuntimeConfig references an UpboundRuntimeConfig, since it's otherwise not obvious why the DRC is necessary and how they're related.
