### PR TITLE
update example v2 providerConfigs to ClusterProviderConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Next, wrap the code block in a `<div id>` that matches the hover label:
 <div id="pc-upbound-auth">
 
 ```yaml 
-apiVersion: azure.upbound.io/v1beta1
+apiVersion: azure.m.upbound.io/v1beta1
 kind: ProviderConfig
 metadata:
   name: default

--- a/docs/guides/intelligent-controllers/intelligent-control-planes.md
+++ b/docs/guides/intelligent-controllers/intelligent-control-planes.md
@@ -113,8 +113,8 @@ Configure the AWS ProviderConfig:
 
 ```shell
 kubectl apply -f - <<EOF
-apiVersion: aws.upbound.io/v1beta1
-kind: ProviderConfig
+apiVersion: aws.m.upbound.io/v1beta1
+kind: ClusterProviderConfig
 metadata:
   name: default
 spec:

--- a/docs/guides/usecases/managed-resources.md
+++ b/docs/guides/usecases/managed-resources.md
@@ -120,12 +120,12 @@ kubectl create secret generic aws-secret \
 Now that your cluster has access to your AWS credentials, you need to create a
 `ProviderConfig` that tells the provider to load credentials from the secret.
 
-Create a new file called `providerconfig.yaml` and paste the configuration
+Create a new file called `clusterproviderconfig.yaml` and paste the configuration
 below:
 
 ```yaml
-apiVersion: aws.upbound.io/v1beta1
-kind: ProviderConfig
+apiVersion: aws.m.upbound.io/v1beta1
+kind: ClusterProviderConfig
 metadata:
   name: default
 spec:


### PR DESCRIPTION
Update v2 provider resource examples to use v2 ProviderConfigs. 

Addressing this error when walking through Use Cases -> Manage external resources with providers page. 
```
(base) {25-08-12 12:04}~/projects/20250812-uxpv2-docs-launch-testing/managed-resource-qs ➭ vi bucket.yaml
(base) {25-08-12 12:05}~/projects/20250812-uxpv2-docs-launch-testing/managed-resource-qs ➭ kubectl create -f bucket.yaml
bucket.s3.aws.m.upbound.io/crossplane-bucket-l8czt created
(base) {25-08-12 12:05}~/projects/20250812-uxpv2-docs-launch-testing/managed-resource-qs ➭ kubectl get buckets.s3.aws.m.upbound.io
NAME                      SYNCED   READY   EXTERNAL-NAME             AGE
crossplane-bucket-l8czt   False            crossplane-bucket-l8czt   11s
(base) {25-08-12 12:05}~/projects/20250812-uxpv2-docs-launch-testing/managed-resource-qs ➭ kgetstatus buckets.s3.aws.m.upbound.io crossplane-bucket-l8czt
status:
  atProvider: {}
  conditions:
  - lastTransitionTime: "2025-08-12T17:05:31Z"
    message: 'connect failed: cannot initialize the Terraform plugin SDK async external
      client: cannot get terraform setup: cannot get referenced ProviderConfig: ClusterProviderConfig.aws.m.upbound.io
      "default" not found'
    observedGeneration: 2
    reason: ReconcileError
    status: "False"
    type: Synced
```
Updated a similar page with a change. 