### PR TITLE
remove references to web-ui in the 'Manage external resources with providers' page

### DIFF
--- a/docs/guides/usecases/managed-resources.md
+++ b/docs/guides/usecases/managed-resources.md
@@ -48,12 +48,6 @@ up uxp install
 
 Upbound installs UXP on your local cluster via Helm chart.
 
-Launch the Upbound Crossplane WebUI for more insight into your resources:
-
-```shell
-up uxp web-ui open
-```
-
 
 ## Install the provider
 


### PR DESCRIPTION
We currently cannot see managed resources in the web-ui page right now so I would like to remove references to it in the Managed resources page. 
Source: https://upboundio.slack.com/archives/C095R0X226B/p1755099398115809?thread_ts=1755024149.910279&cid=C095R0X226B

