### PR TITLE
Redesign Intro Page

### DIFF
--- a/docs/getstarted/overview.md
+++ b/docs/getstarted/overview.md
@@ -24,8 +24,43 @@ reliability, performance, and developer experience.
 ## Already using open source Crossplane?
 <!-- vale Google.WordList = NO -->
 If you're already using Crossplane and want to check out Upbound Crossplane
-2.0, follow our [Upgrade Guide][upgrade] to see how Upbound can enhance your existing
-workflow.
+2.0, you can upgrade an existing Crossplane cluster with Helm or the `up`
+CLI.
+
+:::important
+For more details, follow our [Upgrade Guide][upgrade] to see how Upbound can enhance your existing workflow.
+:::
+<Tabs>
+
+<TabItem value="Helm Install">
+
+```shell
+export UXP_VERSION=<UXP v2 version>
+helm upgrade --install crossplane --namespace crossplane-system oci://xpkg.upbound.io/upbound/crossplane --version "${UXP_VERSION}" --set "upbound.manager.imagePullSecrets[0].name=uxpv2-pull,webui.imagePullSecrets[0].name=uxpv2-pull,apollo.imagePullSecrets[0].name=uxpv2-pull"
+
+```
+</TabItem>
+
+<TabItem value="Up CLI">
+
+Download the `up` CLI and upgrade an existing test cluster.
+
+**Download the CLI:**
+
+```shell
+curl -sL "https://cli.upbound.io" | sh
+```
+
+**Upgrade an existing Crossplane cluster to UXP:**
+
+```shell
+up uxp upgrade
+```
+
+</TabItem>
+
+</Tabs>
+
 <!-- vale Google.WordList = YES -->
 
 

--- a/src/components/GetStartedCallout.js
+++ b/src/components/GetStartedCallout.js
@@ -221,10 +221,9 @@ export function GetStarted() {
 
   return (
     <section className="get-started-section">
-      <h2>🚀 Sign up and install the Upbound CLI</h2>
+      <h2>🚀 Install the Upbound CLI</h2>
       <ul>
-        <li>Create an account on Upbound by <a href="https://accounts.upbound.io/register">registering your organization</a>.</li>
-        <li>Install the <a href="/manuals/cli/overview">up</a> CLI to gain access to all Upbound's tooling on your machine.</li>
+       <li>Install the <a href="/manuals/cli/overview">up</a> CLI to gain access to all Upbound's tooling on your machine.</li>
       </ul>
       
       <div className="code-block">
@@ -245,10 +244,6 @@ export function GetStarted() {
         Find more installation methods on the <a href="/manuals/cli/overview">Up CLI installation guide</a>.
       </div>
       
-      <div className="tip-box">
-        <div className="tip-label">TIP</div>
-        Get started with Upbound using the free <em>Community</em> plan or upgrade to a <em>Standard</em> plan. For more information, review our <a href="https://upbound.io/pricing">pricing plans</a>
-      </div>
     </section>
   );
 }


### PR DESCRIPTION
Adds starting point for Crossplane to UXP with helm and up install.

Removes pricing plan CTAs.