### PR TITLE
Drop image pull secrets from uxp upgrade

### DIFF
--- a/docs/getstarted/upgrade-to-upbound/upgrade-to-uxp.md
+++ b/docs/getstarted/upgrade-to-upbound/upgrade-to-uxp.md
@@ -148,7 +148,7 @@ Choose one of these methods:
 **Helm:**
 ```bash
 export UXP_VERSION=2.0.2-up.2                                      
-helm upgrade --install crossplane --namespace crossplane-system oci://xpkg.upbound.io/upbound/crossplane --version "${UXP_VERSION}" --set "upbound.manager.imagePullSecrets[0].name=uxpv2-pull,webui.imagePullSecrets[0].name=uxpv2-pull,apollo.imagePullSecrets[0].name=uxpv2-pull" 
+helm upgrade --install crossplane --namespace crossplane-system oci://xpkg.upbound.io/upbound/crossplane --version "${UXP_VERSION}"
 ```
 
 :::tip


### PR DESCRIPTION
Drops image pull secrets from uxp upgrade since it is no longer required.