### PR TITLE
Official package policy changed

### DIFF
--- a/docs/manuals/uxp/features/official-package-support.md
+++ b/docs/manuals/uxp/features/official-package-support.md
@@ -13,7 +13,7 @@ new capabilities, user-defined logic, and add-ons.
 Patch version releases of Official Packages require a
 commercial license, available for users on a Standard plan or greater.
 
-## Learn about Packages
+## Learn about packages
 
 Read the [package concept][package-concept] documentation to learn how packages
 work in Upbound Crossplane. Read the Official Package [policies][policies]


### PR DESCRIPTION
## Description
Official Packages no longer require Upbound Crossplane

## Type of change
- [x] Bug fix (typo, broken link, incorrect info)
- [ ] Content update (new info, clarification, reorganization)  
- [ ] New content (new page, section, or guide)

## Checklist
- [x] I ran `make lint` locally (or will fix Vale suggestions in review)
- ~[ ] Links work and point to the right places~
- ~[ ] If this adds new content, I tested the examples/instructions~

## Additional notes

