### PR TITLE
Fix step numbers in istio docs

### DIFF
--- a/docs/manuals/spaces/howtos/self-hosted/certs.md
+++ b/docs/manuals/spaces/howtos/self-hosted/certs.md
@@ -264,8 +264,11 @@ If `up` can't connect to your control plane, follow [this guide to create a new 
 
 ## Troubleshooting
 
-The following `openssl` command is useful to examine your certificate:
-- `openssl s_client -connect proxy.upbound-127.0.0.1.nip.io:443 -showcerts`
+Examine your certificate with `openssl`:
+
+```shell
+openssl s_client -connect proxy.upbound-127.0.0.1.nip.io:443 -showcerts
+```
 
 [istioctl]: https://istio.io/latest/docs/ops/diagnostic-tools/istioctl/
 [up-profile]: /manuals/cli/howtos/profile-config/


### PR DESCRIPTION
## Description

My IDE complains about ordered lists and markdown typically handles it by using `1.` for each item.

I looked at the preview and i actually need to set the correct number for each item 😅 


## Type of change
- [x] Bug fix (typo, broken link, incorrect info)
- [ ] Content update (new info, clarification, reorganization)  
- [ ] New content (new page, section, or guide)

## Checklist
- [ ] I ran `make lint` locally (or will fix Vale suggestions in review)
- [ ] Links work and point to the right places
- [ ] If this adds new content, I tested the examples/instructions

## Additional notes
<!-- Any context, screenshots, or notes for reviewers -->
