### PR TITLE
Remove deprecated note from mcp-connector, feature is not deprecated

### DIFF
--- a/docs/manuals/spaces/howtos/mcp-connector-guide.md
+++ b/docs/manuals/spaces/howtos/mcp-connector-guide.md
@@ -5,12 +5,6 @@ description: A tutorial to configure a Space with Argo to declaratively create a
   manage control planes
 ---
 
-:::important
-
-This feature is set to be deprecated in favor of the [API Connector][api-connector]
-
-:::
-
 In this tutorial, you learn how to configure a Kubernetes app cluster to communicate with a control plane in an Upbound self-hosted Space.
 
 The [control plane connector][control-plane-connector] bridges your Kubernetes application clusters---running outside of Upbound--to your control planes running in Upbound. This allows you to interact with your control plane's API right from the app cluster. The claim APIs you define via `CompositeResourceDefinitions` are available alongside Kubernetes workload APIs like `Pod`. In effect, control plane connector provides the same experience as a locally installed Crossplane.


### PR DESCRIPTION
## Description
<!-- Brief description of what this PR changes or adds. -->

The deprectated note is not valid, api-conntector is not scheduled yet.

## Type of change
- [x] Bug fix (typo, broken link, incorrect info)
- [ ] Content update (new info, clarification, reorganization)  
- [ ] New content (new page, section, or guide)

## Checklist
- [ ] I ran `make lint` locally (or will fix Vale suggestions in review)
- [ ] Links work and point to the right places
- [ ] If this adds new content, I tested the examples/instructions

## Additional notes
<!-- Any context, screenshots, or notes for reviewers -->
