### PR TITLE
Correct provider access policy language

### DIFF
--- a/docs/manuals/packages/providers/provider-families.md
+++ b/docs/manuals/packages/providers/provider-families.md
@@ -30,7 +30,7 @@ For information on migrating from monolithic providers to provider families read
 ## Installing a provider family
 
 :::important
-The ability to install any version of an Official Provider **other than the most recent** requires at least a `Team` subscription to Upbound and a package pull secret to be placed on your control plane. Learn more in the section below. 
+Backport releases of Official Providers require at least a `Standard` subscription to Upbound and a package pull secret to be placed on your control plane. Main releases published within the last 12 months are available to all users. Learn more in the [package policies][package-policies].
 :::
 
 Installing a provider family is identical to installing other Crossplane providers.
@@ -182,3 +182,4 @@ metadata:
 [family-providers-migration-guide]: /manuals/packages/providers/migration
 [upbound-marketplace]: https://marketplace.upbound.io/providers?tier=official
 [controllerconfig]: https://docs.crossplane.io/latest/concepts/packages/#speccontrollerconfigref
+[package-policies]: /manuals/packages/policies

--- a/docs/manuals/packages/providers/pull-secrets.md
+++ b/docs/manuals/packages/providers/pull-secrets.md
@@ -1,11 +1,11 @@
 ---
 title: Pull secrets
 sidebar_position: 1
-description: Learn how to configure access to older Official providers versions from
+description: Learn how to configure access to backport releases of Official providers from
   the Marketplace
 ---
 
-You must configure a pull secret on your control plane to pull any non-latest version of an Official Provider. If you're on
+You must configure a pull secret on your control plane to pull backport releases of Official Providers. If you're on
 Crossplane, UXP v1.18 or later, UXP v1.16.4, or UXP v1.17.3, use the ImageConfig API. Otherwise, configure a pull secret for each provider pod.
 
 :::important


### PR DESCRIPTION
Corrects outdated provider access policy language in two documentation pages:

Changes:
  - Replaces "Team" subscription with "Standard" (current terminology)
  - Clarifies that only backport releases require a Standard+ subscription
  - Emphasizes that main releases published within the last 12 months remain available to all users## Description
<!-- Brief description of what this PR changes or adds. -->

## Type of change
- [ ] Bug fix (typo, broken link, incorrect info)
- [x] Content update (new info, clarification, reorganization)  
- [ ] New content (new page, section, or guide)

## Checklist
- [ ] I ran `make lint` locally (or will fix Vale suggestions in review)
- [ ] Links work and point to the right places
- [ ] If this adds new content, I tested the examples/instructions

## Additional notes
<!-- Any context, screenshots, or notes for reviewers -->
