### PR TITLE
Add release notes for up v0.42.1

### DIFF
--- a/docs/reference/release-notes/up-cli.md
+++ b/docs/reference/release-notes/up-cli.md
@@ -24,6 +24,19 @@ Any important warnings or necessary information
 
 -->
 
+## v0.42.1
+
+### Release Date: 2025-11-04
+
+##### What's Changed
+
+- Added support for Go and go-templating as test languages in `up project init`.
+
+##### Bug Fixes
+
+- Fixed issues in the go-templating test implementation that prevented it from
+  executing templates correctly.
+
 ## v0.42.0
 
 ### Release Date: 2025-10-31


### PR DESCRIPTION
## Description

Release notes for `up` v0.42.1.

## Type of change

~- [ ] Bug fix (typo, broken link, incorrect info)~
- [x] Content update (new info, clarification, reorganization)  
~- [ ] New content (new page, section, or guide)~

## Checklist

- [x] I ran `make lint` locally (or will fix Vale suggestions in review)
- [x] Links work and point to the right places
~- [ ] If this adds new content, I tested the examples/instructions~
