### PR TITLE
Update spacing to show FAQ question instead of "Details"

### DIFF
--- a/docs/manuals/platform/concepts/identity-management/robots.md
+++ b/docs/manuals/platform/concepts/identity-management/robots.md
@@ -25,21 +25,19 @@ Make sure you've created the desired robot before assigning it to a team. To ass
 ## Frequently asked questions
 
 <details>
-
 <summary>What's the difference between a robot token and a personal access token?</summary>
+
 A robot token is like a service account. They have their own identity like service principals in a cloud provider.
 
 A [personal access token][personal-access-token] or "PAT" is a long-lived serialization of a specific Upbound user's identity. Your personal access token can do everything your user can do in Upbound. Only use PATs when necessary and never share them with others.
 
 </details>
-
 <details>
-
 <summary>When should you use a robot token for interacting with Upbound?</summary>
+
 In Upbound, robot tokens are currently scoped to inheriting Upbound Marketplace repository permissions from a [team][team] they're assigned to.
 
 You should use a robot token for your Upbound Marketplace CI to push new tags or as a package pull secret for private repositories.
-
 </details>
 
 [up-cli]: /reference/cli-reference


### PR DESCRIPTION
## Description
<!-- Brief description of what this PR changes or adds. -->

## Type of change
- [x] Bug fix (typo, broken link, incorrect info)
- [ ] Content update (new info, clarification, reorganization)  
- [ ] New content (new page, section, or guide)

## Checklist
- [x] I ran `make lint` locally (or will fix Vale suggestions in review)
- [ ] Links work and point to the right places
- [ ] If this adds new content, I tested the examples/instructions

## Additional notes
<!-- Any context, screenshots, or notes for reviewers -->

Updates the "details" tags with new lines to render the question rather than "Details" in the FAQ dropdown