### PR TITLE
feat(docs): add router tracing and metrics details to space observability page

### DIFF
--- a/docs/manuals/spaces/howtos/self-hosted/space-observability.md
+++ b/docs/manuals/spaces/howtos/self-hosted/space-observability.md
@@ -165,7 +165,7 @@ Span: ingress
 
 ## Available metrics
 
-Space-level observability collects metrics and traces from multiple infrastructure components:
+Space-level observability collects metrics from multiple infrastructure components:
 
 ### Infrastructure component metrics
 


### PR DESCRIPTION
## Description

Add documentation for configuring distributed tracing on the Spaces router, including sampling configuration, TLS settings for external collectors, custom trace tags, and example trace output. Also adds P95 latency query example to the metrics section.

<!-- Brief description of what this PR changes or adds. -->

## Type of change
- [ ] Bug fix (typo, broken link, incorrect info)
- [ ] Content update (new info, clarification, reorganization)  
- [x] New content (new page, section, or guide)

## Checklist
- [x] I ran `make lint` locally (or will fix Vale suggestions in review)
- [x] Links work and point to the right places
- [ ] If this adds new content, I tested the examples/instructions

## Additional notes
Source material: https://github.com/upbound/spaces/blob/main/docs/observability/metrics/spaces-router.md and https://github.com/upbound/spaces/blob/main/docs/observability/traces/spaces-router.md
