### PR TITLE
docs(uxp): add commercial-only features summary table to overview

### DIFF
--- a/docs/manuals/uxp/overview.md
+++ b/docs/manuals/uxp/overview.md
@@ -28,6 +28,17 @@ Upbound Crossplane comes with a number of features that help you start, run, and
 
 UXP is available to any users under Upbound's Community plan. Commercial licenses are available. Some features are available for Community plan users, while others require a commercial license. See [license management][licensing] for more details.
 
+## Commercial-only Features
+
+Users on a **Standard Plan** or greater have access to commercial features that enhance the reliability, efficiency, and supportability of their control planes. For more information, see our [pricing plans][pricing] or [contact our sales team][contact-sales].
+
+| Feature | Benefit |
+|---------|---------|
+| [Backup and Restore][backup-restore] | Automatically schedule control plane snapshots for disaster recovery and seamless upgrades. |
+| [Function Scale-to-Zero][function-scale-to-zero] | Reduce resource consumption by automatically scaling composition functions to zero when idle. |
+| [Official Package Patch Releases][official-package-support] | Access patch releases of Official Providers with security fixes and bug patches. |
+| [Provider Pod Autoscaling][provider-vpa] | Dynamically adjust CPU and memory for provider pods to handle performance spikes. |
+
 ## How-tos 
 
 To learn about Crossplane and UXP features, read the [how-to guides][guides].
@@ -50,3 +61,9 @@ Read the [Get Started][get-started] guide to learn how to use UXP to build your 
 [features]: /manuals/uxp/features/intelligent-control-planes
 [guides]: /manuals/uxp/howtos/uxp-deployment
 [get-started]: /getstarted
+[backup-restore]: /manuals/uxp/features/backup-and-restore
+[function-scale-to-zero]: /manuals/uxp/howtos/function-scale-to-zero
+[official-package-support]: /manuals/uxp/features/official-package-support
+[provider-vpa]: /manuals/uxp/howtos/provider-vpa
+[pricing]: https://www.upbound.io/pricing
+[contact-sales]: https://www.upbound.io/contact-us


### PR DESCRIPTION
## Description
Add a "Commercial-only Features" section to the UXP overview page (`/manuals/uxp/overview`) that provides a quick-reference summary table of Standard Plan features. This helps users quickly discover what commercial features are available without navigating through multiple pages.

The table includes:
- **Backup and Restore** - Automatic control plane snapshots for disaster recovery
- **Function Scale-to-Zero** - Reduce resource consumption with idle function scaling
- **Official Package Patch Releases** - Access to security fixes and bug patches
- **Provider Pod Autoscaling** - Dynamic CPU/memory adjustment for provider pods

Each feature links to its detailed documentation page.

## Type of change
- [ ] Bug fix (typo, broken link, incorrect info)
- [ ] Content update (new info, clarification, reorganization)  
- [x] New content (new page, section, or guide)

## Checklist
- [ ] I ran `make lint` locally (or will fix Vale suggestions in review)
- [x] Links work and point to the right places
- [x] If this adds new content, I tested the examples/instructions

## Additional notes
This complements the existing lock icons in navigation and "Standard Plan Feature" callouts on individual feature pages by providing a consolidated view on the overview page.

<img width="2300" height="1796" alt="20260106-145434@2x" src="https://github.com/user-attachments/assets/a249e07b-2cfb-4c28-aa53-6287d623736f" />
