### PR TITLE
fix(docs): FIPS subscription clarification and wide table overflow fix

### DIFF
--- a/docs/manuals/packages/policies.md
+++ b/docs/manuals/packages/policies.md
@@ -33,7 +33,7 @@ The following policies govern how you can access, receive support for, and under
 | Availability Window                      | The duration that a release remains pullable from the xpkg.upbound.io registry.<br/>**Main releases**: available for 12 months from the release date. <br/>**Backport releases**: available for 18 months from the release date.                                                                                                                                                                                                                                             |
 | Availability vs Support                  | **Availability**: how long a release remains pullable from the registry (12 months for main releases, 18 months for backport releases). **Support**: the duration Upbound provides active support for a release (12 months from the minor version release date). A package may be available after its support window has ended.                                                                                                                                              |
 | SBOM                                     | A software bill of materials (SBOM) lists all the software components and their versions used in the published package. Upstream main releases are unsigned and have no SBOM. All downstream releases published to xpkg.upbound.io are signed and include an SBOM.                                                                                                                                                                                                           |
-| FIPS                                     | FIPS-compatible artifacts are available for all Upbound Official and Partner packages and require an Enterprise+ license.                                                                                                                                                                                                                                                                                                                                                    |
+| FIPS                                     | FIPS-compatible artifacts are available for all Upbound Official and Partner packages and require a Business Critical subscription.                                                                                                                                                                                                                                                                                                                                                    |
 
 ## At a Glance
 
@@ -42,13 +42,13 @@ The following policies govern how you can access, receive support for, and under
 - Upbound publishes packages to both the Crossplane and Upbound registries.
 - Official package main releases are available at no cost to all community members.
 - Backport releases of past minor versions require paid subscriptions to support extra maintenance costs.
-- FIPS-compatible artifact (packages and UXP) versions are available with paid subscriptions.
+- FIPS-compatible artifact (packages and UXP) versions are available with a Business Critical subscription.
 
 ### Which Package Versions Can You Access
 
 - **Community user or no subscription?** You can pull all main releases published within the last 12 months.
 - **Standard, Enterprise, or Business Critical subscription?** You can pull all main and backport releases (with configured pull secrets for backports).
-- **Need FIPS-compatible packages?** Requires Enterprise+ subscription.
+- **Need FIPS-compatible packages?** Requires a Business Critical subscription.
 
 ## Source Code and License
 
@@ -117,7 +117,7 @@ By default, Upbound backports security fixes to minor releases that were publish
 
 - All downstream releases (main and backport) are signed and include an SBOM.
 - Upstream main releases aren't signed and don't include an SBOM.
-- FIPS-compatible artifacts are available for all Upbound Official and Partner packages and require an Upbound [Enterprise+ subscription][pricing-page].
+- FIPS-compatible artifacts are available for all Upbound Official and Partner packages and require an Upbound [Business Critical subscription][pricing-page].
 
 ### Requesting a fix or backport
 
@@ -208,7 +208,7 @@ Upbound customers with a [Standard+ subscription][pricing-page] may submit a sup
 
 ### Publish summary matrix
 
-| Release type        | Crossplane runtime  | Source                     | Distribution         | Signed | SBOM | FIPS-compatible<br/>packages available<br/>(Enterprise+) | Availability window | Subscription<br/>required | Requires<br/>pull secrets | Cadence                               | Testing/quality gating                       |
+| Release type        | Crossplane runtime  | Source                     | Distribution         | Signed | SBOM | FIPS-compatible<br/>packages available<br/>(Business Critical) | Availability window | Subscription<br/>required | Requires<br/>pull secrets | Cadence                               | Testing/quality gating                       |
 | ------------------- | ------------------- | -------------------------- | -------------------- | ------ | ---- | -------------------------------------------------------- | ------------------- | ------------------------- | ------------------------- | ------------------------------------- | -------------------------------------------- |
 | Upstream main       | OSS Crossplane, UXP | `crossplane-contrib/`      | `xpkg.crossplane.io` | No     | No   | No                                                       | Unlimited           | None                      | No                        | Follows Crossplane schedule or faster | Unit + basic integration                     |
 | Downstream main     | OSS Crossplane, UXP | `upbound` (private mirror) | `xpkg.upbound.io`    | Yes    | Yes  | Yes                                                      | 12 months           | None                      | No                        | Ships with upstream main              | Extended matrix; cloud validation; CVE-gated |

--- a/docs/manuals/packages/policies.md
+++ b/docs/manuals/packages/policies.md
@@ -208,11 +208,15 @@ Upbound customers with a [Standard+ subscription][pricing-page] may submit a sup
 
 ### Publish summary matrix
 
+<ScrollTable>
+
 | Release type        | Crossplane runtime  | Source                     | Distribution         | Signed | SBOM | FIPS-compatible<br/>packages available<br/>(Business Critical) | Availability window | Subscription<br/>required | Requires<br/>pull secrets | Cadence                               | Testing/quality gating                       |
 | ------------------- | ------------------- | -------------------------- | -------------------- | ------ | ---- | -------------------------------------------------------- | ------------------- | ------------------------- | ------------------------- | ------------------------------------- | -------------------------------------------- |
 | Upstream main       | OSS Crossplane, UXP | `crossplane-contrib/`      | `xpkg.crossplane.io` | No     | No   | No                                                       | Unlimited           | None                      | No                        | Follows Crossplane schedule or faster | Unit + basic integration                     |
 | Downstream main     | OSS Crossplane, UXP | `upbound` (private mirror) | `xpkg.upbound.io`    | Yes    | Yes  | Yes                                                      | 12 months           | None                      | No                        | Ships with upstream main              | Extended matrix; cloud validation; CVE-gated |
 | Downstream backport | OSS Crossplane, UXP | `upbound` (private mirror) | `xpkg.upbound.io`    | Yes    | Yes  | Yes                                                      | 18 months           | [Standard+][pricing-page] | Yes                       | As needed (eligibility-based)         | Extended matrix; cloud validation; CVE-gated |
+
+</ScrollTable>
 
 ## Package versions
 

--- a/src/components/ScrollTable.js
+++ b/src/components/ScrollTable.js
@@ -1,0 +1,66 @@
+import { useRef, useEffect, useState, useCallback } from 'react';
+
+/**
+ * ScrollTable - A wrapper component for tables that shows scroll shadow indicators
+ *
+ * Usage in MDX:
+ * <ScrollTable>
+ *
+ * | Column 1 | Column 2 | Column 3 |
+ * |----------|----------|----------|
+ * | Data     | Data     | Data     |
+ *
+ * </ScrollTable>
+ */
+export default function ScrollTable({ children }) {
+  const wrapperRef = useRef(null);
+  const [showLeftShadow, setShowLeftShadow] = useState(false);
+  const [showRightShadow, setShowRightShadow] = useState(false);
+
+  const updateShadows = useCallback(() => {
+    const table = wrapperRef.current?.querySelector('table');
+    if (!table) return;
+
+    const { scrollLeft, scrollWidth, clientWidth } = table;
+    const isScrollable = scrollWidth > clientWidth;
+
+    // Show left shadow if scrolled away from start
+    setShowLeftShadow(isScrollable && scrollLeft > 5);
+
+    // Show right shadow if there's more content to scroll
+    setShowRightShadow(isScrollable && scrollLeft < scrollWidth - clientWidth - 5);
+  }, []);
+
+  useEffect(() => {
+    const table = wrapperRef.current?.querySelector('table');
+    if (!table) return;
+
+    // Initial check
+    updateShadows();
+
+    // Listen for scroll events
+    table.addEventListener('scroll', updateShadows);
+
+    // Listen for resize events
+    const resizeObserver = new ResizeObserver(updateShadows);
+    resizeObserver.observe(table);
+
+    return () => {
+      table.removeEventListener('scroll', updateShadows);
+      resizeObserver.disconnect();
+    };
+  }, [updateShadows]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      className="table-scroll-wrapper"
+      style={{
+        '--show-left-shadow': showLeftShadow ? 1 : 0,
+        '--show-right-shadow': showRightShadow ? 1 : 0,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -410,19 +410,86 @@ html[data-theme="dark"] .planBadge {
 article table,
 .theme-doc-markdown table,
 table {
-    display: table;
+    display: block;
     width: auto;
     min-width: 50%;
     max-width: 100%;
     border-collapse: separate;
     border-spacing: 0;
     border-radius: 0.75rem;
-    overflow: hidden;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
     margin: 1.5rem 0;
     box-shadow: var(--upbound-card-shadow);
     border: 1px solid var(--upbound-border-color);
     background-color: var(--ifm-background-color);
     font-size: 0.9rem;
+}
+
+/* Scrollable table wrapper - use with <ScrollTable> component */
+.table-scroll-wrapper {
+    position: relative;
+    margin: 1.5rem 0;
+}
+
+.table-scroll-wrapper table {
+    margin: 0;
+}
+
+/* Right shadow indicator */
+.table-scroll-wrapper::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 40px;
+    background: linear-gradient(to left,
+        rgba(0, 0, 0, 0.18) 0%,
+        rgba(0, 0, 0, 0.1) 40%,
+        transparent 100%
+    );
+    pointer-events: none;
+    border-radius: 0 0.75rem 0.75rem 0;
+    opacity: var(--show-right-shadow, 1);
+    transition: opacity 0.2s ease;
+}
+
+/* Left shadow indicator */
+.table-scroll-wrapper::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 40px;
+    background: linear-gradient(to right,
+        rgba(0, 0, 0, 0.18) 0%,
+        rgba(0, 0, 0, 0.1) 40%,
+        transparent 100%
+    );
+    pointer-events: none;
+    border-radius: 0.75rem 0 0 0.75rem;
+    opacity: var(--show-left-shadow, 0);
+    transition: opacity 0.2s ease;
+    z-index: 1;
+}
+
+/* Dark mode shadows - use light color for visibility */
+html[data-theme="dark"] .table-scroll-wrapper::after {
+    background: linear-gradient(to left,
+        rgba(255, 255, 255, 0.15) 0%,
+        rgba(255, 255, 255, 0.08) 40%,
+        transparent 100%
+    );
+}
+
+html[data-theme="dark"] .table-scroll-wrapper::before {
+    background: linear-gradient(to right,
+        rgba(255, 255, 255, 0.15) 0%,
+        rgba(255, 255, 255, 0.08) 40%,
+        transparent 100%
+    );
 }
 
 table thead {

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -5,6 +5,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import EditCode from '@site/src/components/EditCode';
 import Hover from '@site/src/components/Hover';
+import ScrollTable from '@site/src/components/ScrollTable';
 import { Standard, Business, Enterprise } from '../components/PlanCallout';
 
 export default {
@@ -13,6 +14,7 @@ export default {
   TabItem,
   EditCode,
   Hover,
+  ScrollTable,
   Standard,
   Business,
   Enterprise,


### PR DESCRIPTION
## Summary

- Clarify that FIPS-compatible packages require a Business Critical subscription
- Fix wide table overflow issue where tables with many columns (like the Publish summary matrix) would overlap the right sidebar

## Changes

### FIPS Documentation
- Update table to clarify FIPS packages require Business Critical subscription

### Table Overflow Fix
- Add `ScrollTable` React component with scroll-aware shadow indicators
- Update CSS to enable horizontal scrolling on tables (`display: block`, `overflow-x: auto`)
- Register `ScrollTable` in MDXComponents for global MDX availability
- Wrap the 11-column Publish summary matrix table with `<ScrollTable>`

The scroll shadow indicators appear dynamically based on scroll position to hint that there's more content to scroll.

## Test plan

- [ ] Verify FIPS clarification is accurate in the Publish summary matrix
- [ ] Navigate to Package Policies page and verify the wide table no longer overlaps the sidebar
- [ ] Verify scroll shadows appear on the right when table loads
- [ ] Scroll the table and verify left shadow appears, right shadow disappears at end
- [ ] Test in both light and dark mode