### PR TITLE
Update Spaces collector values for setting API keys

### DIFF
--- a/docs/manuals/spaces/howtos/self-hosted/space-observability.md
+++ b/docs/manuals/spaces/howtos/self-hosted/space-observability.md
@@ -43,12 +43,18 @@ To configure how Upbound exports, review the `spacesCollector` value in your Spa
 ```yaml
 observability:
   spacesCollector:
+    env:
+      - name: API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: my-secret
+            key: api-key
     config:
       exporters:
         otlphttp:
           endpoint: "<your-endpoint>"
           headers:
-            api-key: YOUR_API_KEY
+            api-key: ${env:API_KEY}
       exportPipeline:
         logs:
           - otlphttp
@@ -66,7 +72,7 @@ provider-kubernetes.
 ### Router metrics
 
 The Spaces router component uses Envoy as a reverse proxy and exposes detailed
-metrics about request handling, circuit breakers, and connection pooling. 
+metrics about request handling, circuit breakers, and connection pooling.
 Upbound collects these metrics in your Space after you enable Space-level
 observability.
 


### PR DESCRIPTION
## Description

We will have a number of patch releases going out to add this configuration to the Spaces helm chart.

This only applies to the following versions: 1.16+, 1.15.2, 1.14.3, 1.13.4, 1.12.3


## Type of change
- [ ] Bug fix (typo, broken link, incorrect info)
- [x] Content update (new info, clarification, reorganization)  
- [ ] New content (new page, section, or guide)

## Checklist
- [ ] I ran `make lint` locally (or will fix Vale suggestions in review)
- [ ] Links work and point to the right places
- [ ] If this adds new content, I tested the examples/instructions

## Additional notes
<!-- Any context, screenshots, or notes for reviewers -->
