### PR TITLE
Add doc to reference up space mirror command in Spaces docs

### DIFF
--- a/docs/manuals/spaces/howtos/self-hosted/mirror-images.md
+++ b/docs/manuals/spaces/howtos/self-hosted/mirror-images.md
@@ -13,7 +13,15 @@ section of the CLI reference.
 ## Prerequisites
 
 * The [Up CLI][cli-reference] installed
-* An Upbound token file (JSON with `accessId` and `token`) for registry auth
+* An Upbound token file (JSON with `accessId` and `token`) for registry auth.
+  Example:
+
+  ```json
+  {
+    "accessId": "<your-access-id>",
+    "token": "<your-token>"
+  }
+  ```
 
 ## Mirror to a local directory
 

--- a/docs/manuals/spaces/howtos/self-hosted/mirror-images.md
+++ b/docs/manuals/spaces/howtos/self-hosted/mirror-images.md
@@ -48,8 +48,7 @@ up space mirror -v 1.15.2 --destination-registry=myregistry.io --token-file=upbo
 ```
 
 :::tip
-Use `--dry-run` to list the artifacts that would be mirrored without copying
-them. This checks proper access to the Upbound registry.
+Use `--dry-run` to list artifacts the command would mirror without copying them. This verifies you have proper access to the Upbound registry.
 :::
 
 [cli-mirror]: /reference/cli-reference#up-space-mirror

--- a/docs/manuals/spaces/howtos/self-hosted/mirror-images.md
+++ b/docs/manuals/spaces/howtos/self-hosted/mirror-images.md
@@ -1,0 +1,56 @@
+---
+title: Mirror Spaces images
+description: Mirror OCI artifacts for a Spaces version to local storage or a
+  private registry.
+---
+
+`up space mirror` copies all OCI artifacts for a given Spaces version to a local
+directory (as `.tar.gz` files) or a container registry.
+
+For full usage, flags, and examples, see the [up space mirror][cli-mirror]
+section of the CLI reference.
+
+## Prerequisites
+
+* The [Up CLI][cli-reference] installed
+* An Upbound token file (JSON with `accessId` and `token`) for registry auth
+
+## Mirror to a local directory
+
+To export artifacts as `.tar.gz` files into a directory:
+
+```bash
+up space mirror -v <version> --output-dir=<path> --token-file=<path-to-token.json>
+```
+
+Example:
+
+```bash
+up space mirror -v 1.15.2 --output-dir=/tmp/spaces-artifacts --token-file=upbound-token.json
+```
+
+## Mirror to a private registry
+
+To push artifacts to your own container registry:
+
+1. Log in to the registry (for example, `docker login myregistry.io`).
+
+2. Run the mirror command with `--destination-registry`:
+
+```bash
+up space mirror -v <version> --destination-registry=<registry> --token-file=<path-to-token.json>
+```
+
+Example:
+
+```bash
+up space mirror -v 1.15.2 --destination-registry=myregistry.io --token-file=upbound-token.json
+```
+
+:::tip
+Use `--dry-run` to list the artifacts that would be mirrored without copying
+them. This checks proper access to the Upbound registry.
+:::
+
+[cli-mirror]: /reference/cli-reference#up-space-mirror
+[cli-reference]: /reference/cli-reference


### PR DESCRIPTION
## Description

`up space mirror` is only findable in the CLI reference, this adds a page to the Spaces docs to help users potentially find this easier. 

coming out https://upboundio.slack.com/archives/C0748V0TWET/p1771970352678649?thread_ts=1771967480.692849&cid=C0748V0TWET

## Type of change
- [ ] Bug fix (typo, broken link, incorrect info)
- [ ] Content update (new info, clarification, reorganization)  
- [x] New content (new page, section, or guide)

## Checklist
- [ ] I ran `make lint` locally (or will fix Vale suggestions in review)
- [ ] Links work and point to the right places
- [ ] If this adds new content, I tested the examples/instructions

## Additional notes
<!-- Any context, screenshots, or notes for reviewers -->
