### PR TITLE
Update secrets-proxy.md with alpha feature warning

### DIFF
--- a/docs/manuals/uxp/howtos/secrets-proxy.md
+++ b/docs/manuals/uxp/howtos/secrets-proxy.md
@@ -4,6 +4,11 @@ description: "Learn how to configure the Secrets Proxy to access secrets from an
 sidebar_position: 50
 ---
 
+:::important
+This feature is in Alpha and requires UXP `v2.2`. Secrets proxy should not be used in production environments without testing.
+:::
+
+
 The Secrets Proxy lets Crossplane providers read and write secrets directly
 to HashiCorp Vault instead of storing them as Kubernetes Secrets. Providers
 use the standard Kubernetes Secret API. The Secrets Proxy intercepts those calls and


### PR DESCRIPTION
Added a note about the alpha status of the Secrets Proxy feature and its requirement for UXP v2.2.

## Description
<!-- Brief description of what this PR changes or adds. -->

## Type of change
- [ ] Bug fix (typo, broken link, incorrect info)
- [ ] Content update (new info, clarification, reorganization)  
- [ ] New content (new page, section, or guide)

## Checklist
- [ ] I ran `make vale-file FILE=docs/path/to/file.md` locally for files changed (or will fix Vale suggestions in review)
- [ ] Links work and point to the right places
- [ ] If this adds new content, I tested the examples/instructions

## Additional notes
<!-- Any context, screenshots, or notes for reviewers -->
