### PR TITLE
docs: clarify upjet external API calls metric is provider-aws only

### DIFF
--- a/docs/manuals/uxp/concepts/observability-views.md
+++ b/docs/manuals/uxp/concepts/observability-views.md
@@ -44,7 +44,7 @@ The observability dashboard displays data from two sources:
 2. Time-Series Metrics (Prometheus, Standard editions only)
 
     - Reconciliation metrics provides reconciliation rates per controller to identify stuck or overloaded controllers
-    - External API calls captures the volume of API calls per resource kind to spot providers under heavy load
+    - External API calls captures the volume of API calls per resource kind to spot providers under heavy load. This metric is only available for **provider-aws**—other upjet-based providers (Azure, GCP) don't emit `upjet_resource_external_api_calls_total`.
     - Function latency provides function execution times to identify performance issues
 <!-- vale write-good.Passive = YES -->
 
@@ -102,7 +102,7 @@ webui:
 Your Prometheus needs to scrape UXP components and have these metrics available:
 
 - `controller_runtime_reconcile_total`
-- `upjet_resource_external_api_calls_total`
+- `upjet_resource_external_api_calls_total`—emitted by **provider-aws only**; Azure and GCP upjet-based providers don't support this metric.
 - `function_run_function_seconds_bucket`, `_sum`, `_count`
 
 [web-ui]: /manuals/console/self-service


### PR DESCRIPTION
## Description
<!-- Brief description of what this PR changes or adds. -->
Clarifies that `upjet_resource_external_api_calls_total` is only emitted by `provider-aws`. The "Top 5 External API Calls" chart in the Web UI will be empty for Azure and GCP providers —  this updates the docs to reflect that rather than implying the metric is universally available across all upjet-based providers.

## Type of change
- [x] Bug fix (typo, broken link, incorrect info)
- [ ] Content update (new info, clarification, reorganization)  
- [ ] New content (new page, section, or guide)

## Checklist
- [x] I ran `make vale-file FILE=docs/path/to/file.md` locally for files changed (or will fix Vale suggestions in review)
~- [ ] Links work and point to the right places~
~- [ ] If this adds new content, I tested the examples/instructions~

## Additional notes
<!-- Any context, screenshots, or notes for reviewers -->
