### PR TITLE
Add UXP v2.1.4-up.3 release notes

### DIFF
--- a/docs/reference/release-notes/uxp.md
+++ b/docs/reference/release-notes/uxp.md
@@ -14,6 +14,14 @@ Any important warnings or necessary information
 - User-facing changes
 -->
 
+## v2.1.4-up.3
+
+### Release Date: 2026-04-08
+
+#### What's Changed
+- Bumped Crossplane to [v2.1.4-up.3](https://github.com/upbound/crossplane/releases/tag/v2.1.4-up.3)
+- Added FunctionRunner payload size metrics ([upbound/crossplane#210](https://github.com/upbound/crossplane/pull/210))
+
 ## v2.2.0-up.3
 
 ### Breaking changes

--- a/docs/reference/release-notes/uxp.md
+++ b/docs/reference/release-notes/uxp.md
@@ -19,8 +19,8 @@ Any important warnings or necessary information
 ### Release Date: 2026-04-08
 
 #### What's Changed
-- Bumped Crossplane to [v2.1.4-up.3](https://github.com/upbound/crossplane/releases/tag/v2.1.4-up.3)
-- Added FunctionRunner payload size metrics ([upbound/crossplane#210](https://github.com/upbound/crossplane/pull/210))
+- Bumped Crossplane to v2.1.4-up.3
+- Added FunctionRunner payload size metrics
 
 ## v2.2.0-up.3
 


### PR DESCRIPTION
## Summary
- Adds release notes for UXP v2.1.4-up.3
- Notable change: FunctionRunner payload size metrics backported to 2.1

Part of upbound/upbound-crossplane#188.