### PR TITLE
fix(testing): remove duplicate paragraph and fix grammar errors

### DIFF
--- a/docs/manuals/cli/howtos/testing.md
+++ b/docs/manuals/cli/howtos/testing.md
@@ -7,7 +7,7 @@ description: How to run your control plane project on a development controlplane
 import CrdDocViewer from '@site/src/components/CrdViewer';
 
 Testing ensures your compositions and control planes work as expected, follow
-best practices, and meet your organizations requirements. You can run your
+best practices, and meet your organization's requirements. You can run your
 projects in a development control plane and author tests to verify specific
 capabilities in your project.
 
@@ -83,11 +83,7 @@ live environment. They simulate the composition controller's behavior, allowing
 you to test resource creation, dependencies, and state transitions with mock
 data.
 
-Composition tests validate composition logic without required a live
-environment. They simulate the composition controller's behavior, letting you
-test resource creation, dependencies, and state transitions with mock data.
-
-You can generate test with `up test generate` for composition tests.
+You can generate tests with `up test generate` for composition tests.
 You can write tests in KCL or Python.
 
 For example, to generate a composition test:


### PR DESCRIPTION
## Summary

- Removes a near-identical duplicate paragraph in the composition tests section (copy-paste artifact that also contained a grammar error: "without required a")
- Fixes missing possessive apostrophe: "organizations" → "organization's"
- Fixes pluralisation: "generate test" → "generate tests"

## Test plan

- [ ] Verify rendered page in local dev server looks correct
- [ ] No broken links or formatting regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)