### PR TITLE
fix(composition): remove trailing space from front matter title

### DIFF
--- a/docs/manuals/uxp/concepts/composition/overview.md
+++ b/docs/manuals/uxp/concepts/composition/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Overview 
+title: Overview
 sidebar_position: 1
 description: Understand Crossplane's Composition workflow
 ---


### PR DESCRIPTION
## Summary

- Remove trailing space from the `title` field in the composition overview front matter

## Test plan

- [ ] Verify rendered page title displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)