### PR TITLE
fix(python): correct IDE extension name to 'VS Code'

### DIFF
--- a/docs/manuals/cli/howtos/compositions/python.md
+++ b/docs/manuals/cli/howtos/compositions/python.md
@@ -47,7 +47,7 @@ Before you begin, make sure:
 * You designed your XRD
 * You've added provider dependencies
 * You have Python 3.11+ installed
-* You have the Python Virtual Studio Code extension installed
+* You have the Python VS Code extension installed
 * You understand your XRD schema and what resources you need to create
 
 


### PR DESCRIPTION
## Summary

- Fix incorrect product name: "Python Virtual Studio Code extension" → "Python VS Code extension"
- "Virtual Studio Code" is not a real product name; the correct name is Visual Studio Code, commonly shortened to VS Code

## Test plan

- [ ] Verify rendered page looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)