### PR TITLE
fix(environment-configs): remove unresolved TODO comment

### DIFF
--- a/docs/manuals/uxp/concepts/composition/environment-configs.md
+++ b/docs/manuals/uxp/concepts/composition/environment-configs.md
@@ -5,10 +5,6 @@ description: Environment Configs or EnvironmentConfigs are an in-memory datastor
   used in Compositions
 ---
 
-<!--
-TODO: Add Policies
--->
-
 A Crossplane EnvironmentConfig is a cluster-scoped, strongly typed,
 [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/)-like
 resource used by Compositions. Compositions can use the environment to store


### PR DESCRIPTION
## Summary

- Remove `<!-- TODO: Add Policies -->` comment that was left in production docs

If the Policies section needs to be added, it should be tracked as a separate content issue rather than as an HTML comment visible in the source.

## Test plan

- [ ] Verify rendered page looks correct (the comment was invisible in the rendered output but should not appear in source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)