### PR TITLE
fix(ipaddresses): explain these are egress IPs for firewall allowlisting

### DIFF
--- a/docs/reference/usage/ipaddresses.md
+++ b/docs/reference/usage/ipaddresses.md
@@ -4,6 +4,11 @@ sidebar_position: 19
 description: List of IP addresses used by Upbound control planes
 ---
 
+Upbound control planes communicate with external systems using the following
+egress IP addresses. Add these addresses to your firewall allowlist if your
+cloud provider resources or private endpoints restrict inbound traffic by source
+IP.
+
 Control planes can use any of the following IP addresses:
 
 - 35.238.181.48


### PR DESCRIPTION
## Summary

- The IP addresses page previously listed addresses with no explanation of their purpose or when they matter
- Add a short introductory sentence clarifying these are egress IPs to add to firewall allowlists when cloud provider resources or private endpoints restrict inbound traffic by source IP

## Test plan

- [ ] Verify rendered page looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)