### PR TITLE
fix(adding-dependencies): correct misleading front matter description

### DIFF
--- a/docs/manuals/cli/howtos/adding-dependencies.md
+++ b/docs/manuals/cli/howtos/adding-dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: Add project dependencies 
 sidebar_position: 5
-description: The basic concepts to help you on your Upbound journey
+description: How to add providers, functions, and API dependencies to your control plane project
 ---
 
 This guide explains how to add cloud providers, functions and configurations as


### PR DESCRIPTION
## Summary

- The `description` field in the front matter of `adding-dependencies.md` contained generic placeholder text ("The basic concepts to help you on your Upbound journey") that does not describe the page content
- Replaced with an accurate description of the page

## Test plan

- [ ] Verify the description renders correctly in search results and SEO metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)