### PR TITLE
fix(hub-rbac): correct duplicate Vale suppression directive (NO → YES)

### DIFF
--- a/docs/manuals/platform/concepts/authorization/hub-rbac.md
+++ b/docs/manuals/platform/concepts/authorization/hub-rbac.md
@@ -70,7 +70,7 @@ rules:
   resources: ["controlplanes/k8s"]
   verbs: ["edit"] # or "admin" or "view", depending on access level
 ```
-<!-- vale Google.WordList = NO -->
+<!-- vale Google.WordList = YES -->
 
 
 [upbound-rbac]: /manuals/platform/concepts/authorization/upbound-rbac


### PR DESCRIPTION
## Summary

- The closing Vale directive on line 73 was a duplicate of the opening directive (both used `= NO`)
- The closing directive should re-enable linting with `= YES` to restore Vale checks after the code block

## Test plan

- [ ] Vale linting passes without unexpected suppression

🤖 Generated with [Claude Code](https://claude.com/claude-code)