### PR TITLE
Add UXP v1.20.6-up.2 release notes

### DIFF
--- a/docs/reference/release-notes/uxp.md
+++ b/docs/reference/release-notes/uxp.md
@@ -14,6 +14,16 @@ Any important warnings or necessary information
 - User-facing changes
 -->
 
+## v1.20.6-up.2
+
+### Release Date: 2026-04-22
+
+#### What's Changed
+
+Based on Crossplane [v1.20.6](https://github.com/crossplane/crossplane/releases/tag/v1.20.6).
+
+- Bumped Go to 1.25.9 to cover stdlib CVEs
+
 ## v2.2.1-up.1
 
 ### Release Date: 2026-04-21


### PR DESCRIPTION
Add release notes for UXP v1.20.6-up.2.

Ref upbound/universal-crossplane#528.
Release: https://github.com/upbound/universal-crossplane/releases/tag/v1.20.6-up.2