### PR TITLE
docs(uxp): align UXP install on chart museum (CTP-232)

### DIFF
--- a/docs/getstarted/overview.md
+++ b/docs/getstarted/overview.md
@@ -21,29 +21,32 @@ reliability, performance, and developer experience.
 
 <!-- vale Microsoft.HeadingPunctuation = NO -->
 
-## Already using open source Crossplane?
+## Install Upbound Crossplane
 <!-- vale Google.WordList = NO -->
-If you're already using Crossplane and want to check out Upbound Crossplane
-2.0, you can upgrade an existing Crossplane cluster with Helm or the `up`
-CLI.
+Install Upbound Crossplane (UXP) into a fresh Kubernetes cluster with Helm or
+the `up` CLI.
+
+:::important
+Already running open source Crossplane? Don't run the commands below — follow
+the [Upgrade Guide][upgrade] instead.
+:::
 
 <Tabs>
 
 <TabItem value="Helm Install">
 
 ```shell
-helm upgrade --install crossplane --create-namespace --namespace crossplane-system oci://xpkg.upbound.io/upbound/crossplane --version 2.1.3-up.1
+helm repo add upbound-stable https://charts.upbound.io/stable && helm repo update
+helm install crossplane --namespace crossplane-system --create-namespace upbound-stable/crossplane --devel
 ```
-:::important
-For more details, follow our [Upgrade Guide][upgrade] to see how Upbound can enhance your existing workflow.
-:::
 
 </TabItem>
 
 
 <TabItem value="Up CLI">
 
-Download the `up` CLI and upgrade an existing test cluster.
+Download the `up` CLI and install UXP into the cluster pointed to by your
+current kubeconfig context.
 
 **Download the CLI:**
 
@@ -51,10 +54,10 @@ Download the `up` CLI and upgrade an existing test cluster.
 curl -sL "https://cli.upbound.io" | sh
 ```
 
-**Upgrade an existing Crossplane cluster to UXP:**
+**Install Upbound Crossplane:**
 
 ```shell
-up uxp upgrade
+up uxp install
 ```
 
 </TabItem>

--- a/docs/getstarted/upgrade-to-upbound/upgrade-to-uxp.md
+++ b/docs/getstarted/upgrade-to-upbound/upgrade-to-uxp.md
@@ -219,7 +219,7 @@ path uses a **free Community license**.
     Add the Upbound repository and upgrade your Crossplane cluster:
     ```shell
     helm repo add upbound-stable https://charts.upbound.io/stable && helm repo update
-    helm upgrade --install crossplane --namespace crossplane-system oci://xpkg.upbound.io/upbound/crossplane --version "${UXP_VERSION}"
+    helm upgrade --install crossplane --namespace crossplane-system upbound-stable/crossplane --version "${UXP_VERSION}"
     ```
     </TabItem>
 
@@ -276,7 +276,7 @@ for more information.
     Add the Upbound repository and upgrade your Crossplane cluster:
     ```shell
     helm repo add upbound-stable https://charts.upbound.io/stable && helm repo update
-    helm upgrade --install crossplane --namespace crossplane-system oci://xpkg.upbound.io/upbound/crossplane --version "${UXP_VERSION}"
+    helm upgrade --install crossplane --namespace crossplane-system upbound-stable/crossplane --version "${UXP_VERSION}"
     ```
     </TabItem>
 


### PR DESCRIPTION
## Summary
- Align UXP install/upgrade snippets on the chart museum (`upbound-stable/crossplane`) instead of the OCI chart source. Affects `getstarted/overview.md` and both helm-upgrade snippets in `getstarted/upgrade-to-upbound/upgrade-to-uxp.md`.
- Rework the install section on `getstarted/overview.md`: the page previously led with an upgrade-from-OSS-Crossplane snippet that duplicated the dedicated upgrade guide and left fresh-cluster readers without an install path. The section now installs UXP into a fresh cluster (with `--devel` since UXP charts use the `-up.N` pre-release suffix), and a guardrail `:::important` callout directs OSS users to the upgrade guide.
- Container-image refs (`image.repository` in the helm reference) and Spaces `spaces-artifacts` OCI refs are out of scope and unchanged.

Closes [CTP-232](https://linear.app/upbound/issue/CTP-232/align-uxp-install-docs-on-chart-museum-flow).

## Test plan
- [ ] `npm run build` succeeds
- [ ] Manually verify the rendered Helm-Install / Up CLI tabs on `/getstarted` and the `helm upgrade` snippets on `/getstarted/upgrade-to-upbound/upgrade-to-uxp`